### PR TITLE
enable HAVE_STPCPY for arm/arm64 and x86

### DIFF
--- a/src/main/jni/pdnsd/config.h
+++ b/src/main/jni/pdnsd/config.h
@@ -284,9 +284,7 @@
 #define HAVE_STDLIB_H 1
 
 /* Define to 1 if you have the `stpcpy' function. */
-#if defined(__aarch64__) || defined(__x86_64__)
 #define HAVE_STPCPY 1
-#endif
 
 /* Define to 1 if you have the `stpncpy' function. */
 //#define HAVE_STPNCPY 1


### PR DESCRIPTION
This is a function can be found in all android bionic libc, so, enables this will prevent the build failure for armeabi-v7 ABI.