### PR TITLE
Update sbt and sbt-android-plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ ndkBuild in Android := List()
 
 typedResources in Android := false
 
+resolvers += Resolver.jcenterRepo
+
 resolvers += "JRAF" at "http://JRAF.org/static/maven/2"
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.url("scalasbt releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.10")
+addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.22")
 
 resolvers += Resolver.sbtPluginRepo("snapshots")
 


### PR DESCRIPTION
1. Update sbt-android-pluin to enable multidex support and other bug fixes
2. Update sbt to 0.13.8 to support jcenter resolver, which will speed up dependency resolving according to google.