### PR TITLE
 update dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Help to translate shadowsocks: http://crowdin.net/project/shadowsocks/invite
 
 * JDK 1.7+
 * SBT 0.13.0+
-* Android SDK r21+
-* Android NDK r9+
+* Android SDK r24+
+* Android NDK r10d+
 
 ### BUILD
 


### PR DESCRIPTION
it might be due to the upstream changes. 
with the sdk and ndk version listed it can not be built successfully 
even with google service and other extra packages installed.

update it to my working versions. 
