### PR TITLE
add tcp_nagle_disable in tun2socks

### DIFF
--- a/src/main/jni/badvpn/tun2socks/tun2socks.c
+++ b/src/main/jni/badvpn/tun2socks/tun2socks.c
@@ -1772,6 +1772,9 @@ err_t listener_accept_func (void *arg, struct tcp_pcb *newpcb, err_t err)
     // set client not closed
     client->client_closed = 0;
 
+    // enable TCP_NODELAY
+    tcp_nagle_disable(client->pcb);
+
     // setup handler argument
     tcp_arg(client->pcb, client);
 


### PR DESCRIPTION
Turn on TCP_NODELAY for TCP sockets in lwIP stack.

Notice: I haven't tested on Android yet.