### PR TITLE
Reduce battery usage - Add option to disable notification traffic

### DIFF
--- a/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksService.aidl
+++ b/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksService.aidl
@@ -12,4 +12,6 @@ interface IShadowsocksService {
 
   oneway void start(in Config config);
   oneway void stop();
+
+  oneway void showNotificationTraffic(boolean value);
 }

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -32,6 +32,8 @@
   <string name="bypass_apps_summary">启用该选项，以使所选应用程序的流量不经过代理</string>
   <string name="auto_connect">自动连接</string>
   <string name="auto_connect_summary">随系统启动后台服务</string>
+  <string name="notification_traffic">在通知内显示网络流量</string>
+  <string name="notification_traffic_summary">在屏幕亮起且有网络活动时会更耗电一点。</string>
   <string name="forward_success">后台服务已开始运行。</string>
   <string name="service_failed">无法连接远程服务器</string>
   <string name="nat_no_root">NAT 模式需要 ROOT 权限</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
   <string name="nat">NAT mode (deprecated)</string>
   <string name="nat_summary">Use NAT mode instead of VPN mode. Requires ROOT permission.</string>
   <string name="stat">Network Traffic</string>
+  <string name="notification_traffic">Show traffic in notification</string>
+  <string name="notification_traffic_summary">Causes a little extra but noticeable battery usage when network is active
+    and screen is on.</string>
   <string name="stat_summary">Sent: \t\t\t\t\t%3$s\t↑\t%1$s/s\nReceived: \t%4$s\t↓\t%2$s/s</string>
   <string name="stat_profiles">\n%1$s↑\t%2$s↓</string>
   <string name="traffic_summary">%1$s/s↑\t%2$s/s↓</string>

--- a/src/main/res/xml/pref_all.xml
+++ b/src/main/res/xml/pref_all.xml
@@ -82,6 +82,10 @@
                 android:key="isAutoConnect"
                 android:summary="@string/auto_connect_summary"
                 android:title="@string/auto_connect"/>
+        <SwitchPreference android:key="notificationTraffic"
+                          android:defaultValue="true"
+                          android:title="@string/notification_traffic"
+                          android:summary="@string/notification_traffic_summary"/>
 
         <SwitchPreference android:key="isNAT"
                           android:title="@string/nat"

--- a/src/main/scala/com/github/shadowsocks/BaseService.scala
+++ b/src/main/scala/com/github/shadowsocks/BaseService.scala
@@ -51,6 +51,7 @@ trait BaseService extends Service {
 
   @volatile private var state = State.STOPPED
   @volatile protected var config: Config = null
+  protected var notification: ShadowsocksNotification = _
 
   var timer: Timer = null
   var trafficMonitorThread: TrafficMonitorThread = null
@@ -104,6 +105,11 @@ trait BaseService extends Service {
       if (state == State.STOPPED) {
         startRunner(config)
       }
+    }
+
+    override def showNotificationTraffic(value: Boolean) {
+      val notification = BaseService.this.notification
+      if (notification != null) notification.setShowTraffic(value)
     }
   }
 

--- a/src/main/scala/com/github/shadowsocks/BaseService.scala
+++ b/src/main/scala/com/github/shadowsocks/BaseService.scala
@@ -45,7 +45,7 @@ import android.app.Service
 import android.content.{Intent, Context}
 import android.os.{Handler, RemoteCallbackList}
 import com.github.shadowsocks.aidl.{Config, IShadowsocksService, IShadowsocksServiceCallback}
-import com.github.shadowsocks.utils.{State, TrafficMonitor, TrafficMonitorThread}
+import com.github.shadowsocks.utils.{Key, State, TrafficMonitor, TrafficMonitorThread}
 
 trait BaseService extends Service {
 
@@ -108,6 +108,7 @@ trait BaseService extends Service {
     }
 
     override def showNotificationTraffic(value: Boolean) {
+      ShadowsocksApplication.settings.edit.putBoolean(Key.notificationTraffic, value).apply
       val notification = BaseService.this.notification
       if (notification != null) notification.setShowTraffic(value)
     }

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
@@ -62,6 +62,7 @@ object ShadowsocksApplication {
   lazy val profileManager = new ProfileManager(settings, dbHelper)
 
   def isVpnEnabled = !settings.getBoolean(Key.isNAT, false)
+  def notificationTraffic = settings.getBoolean(Key.notificationTraffic, true)
 
   def getVersionName = try {
     instance.getPackageManager.getPackageInfo(instance.getPackageName, 0).versionName
@@ -90,7 +91,7 @@ class ShadowsocksApplication extends Application {
   import ShadowsocksApplication._
 
   override def onCreate() {
-    java.lang.System.setProperty(LocalLog.LOCAL_LOG_LEVEL_PROPERTY, "ERROR");
+    java.lang.System.setProperty(LocalLog.LOCAL_LOG_LEVEL_PROPERTY, "ERROR")
     ShadowsocksApplication.instance = this
     val tm = TagManager.getInstance(this)
     val pending = tm.loadContainerPreferNonDefault("GTM-NT8WS8", R.raw.gtm_default_container)

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -65,7 +65,6 @@ class ShadowsocksNatService extends BaseService {
   val CMD_IPTABLES_DNAT_ADD_SOCKS = " -t nat -A OUTPUT -p tcp " +
     "-j DNAT --to-destination 127.0.0.1:8123"
 
-  private var notification: ShadowsocksNotification = _
   var closeReceiver: BroadcastReceiver = _
   var connReceiver: BroadcastReceiver = _
   val myUid = android.os.Process.myUid()
@@ -450,7 +449,8 @@ class ShadowsocksNatService extends BaseService {
           flushDns()
 
           changeState(State.CONNECTED)
-          notification = new ShadowsocksNotification(this, config.profileName, true)
+          notification = new ShadowsocksNotification(this, config.profileName, true,
+            ShadowsocksApplication.notificationTraffic)
         } else {
           changeState(State.STOPPED, getString(R.string.service_failed))
           stopRunner()

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksSettings.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksSettings.scala
@@ -172,6 +172,8 @@ class ShadowsocksSettings extends PreferenceFragment with OnSharedPreferenceChan
   }
 
   def onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) = key match {
+    case Key.notificationTraffic => if (activity.bgService != null)
+      activity.bgService.showNotificationTraffic(ShadowsocksApplication.notificationTraffic)
     case Key.isNAT => activity.handler.post(() => {
       activity.deattachService
       activity.attachService

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -65,7 +65,6 @@ class ShadowsocksVpnService extends VpnService with BaseService {
   val PRIVATE_VLAN6 = "fdfe:dcba:9876::%s"
   var conn: ParcelFileDescriptor = _
   var vpnThread: ShadowsocksVpnThread = _
-  private var notification: ShadowsocksNotification = _
   var closeReceiver: BroadcastReceiver = _
 
   var sslocalProcess: Process = _
@@ -238,7 +237,8 @@ class ShadowsocksVpnService extends VpnService with BaseService {
 
         if (resolved && handleConnection) {
           changeState(State.CONNECTED)
-          notification = new ShadowsocksNotification(this, config.profileName)
+          notification = new ShadowsocksNotification(this, config.profileName,
+            ShadowsocksApplication.notificationTraffic)
         } else {
           changeState(State.STOPPED, getString(R.string.service_failed))
           stopRunner()

--- a/src/main/scala/com/github/shadowsocks/utils/Constants.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Constants.scala
@@ -68,6 +68,7 @@ object Key {
   val profiles = "profiles"
   val isNAT = "isNAT"
   val route = "route"
+  val notificationTraffic = "notificationTraffic"
   val stat = "stat"
 
   val isRunning = "isRunning"


### PR DESCRIPTION
This commit reverts "Removed the switch for now", commit 1eda4c47a4abba26f4669967f2c00a1ffca1452e in #447.

Fixed all the IPCs, now it's working fine.

According to my profiling results, `Notification.Builder.build` and `NotificationManager.notify` causes ~2x extra battery usage EACH even after I've done so many optimizations IIRC so it's reasonable to give users an option to turn this additional feature off.

Speaking of IPCs, is it possible to move everything in `ss-local`, `ss-tunnel`, etc. to process `:vpn` and `:nat`? Creating so many additional processes seems unnecessary (and battery draining).