### PR TITLE
Add option: bypass China only

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Help to translate shadowsocks: http://crowdin.net/project/shadowsocks/invite
 
 ### LICENSE
 
-Copyright (C) 2015 Max Lv <max.c.lv@gmail.com>
+Copyright (C) 2016 Max Lv <max.c.lv@gmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/gfwlist/gen.py
+++ b/gfwlist/gen.py
@@ -13,43 +13,8 @@ def main():
     for line in sys.stdin:
         china_list_set.add(IPy.IP(line))
 
-    # 添加内网地址
-    internal_list = IPy.IPSet(map(IPy.IP, [
-        "0.0.0.0/8",
-        "10.0.0.0/8",
-        "100.64.0.0/10",
-        "112.124.47.0/24",
-        "114.114.114.0/24",
-        "127.0.0.0/8",
-        "169.254.0.0/16",
-        "172.16.0.0/12",
-        "192.0.0.0/29",
-        "192.0.2.0/24",
-        "192.88.99.0/24",
-        "192.168.0.0/16",
-        "198.18.0.0/15",
-        "198.51.100.0/24",
-        "203.0.113.0/24",
-        "224.0.0.0/4",
-        "240.0.0.0/4",
-    ]))
-    china_list_set += internal_list
-
-    all = china_list_set
-
-    # 取反
-    # all = IPy.IPSet([IPy.IP("0.0.0.0/0")])
-    # 剔除所有孤立的C段
-    # for ip in china_list_set:
-    #     all.discard(ip)
-
-    # filter = itertools.ifilter(lambda x: len(x) <= 65536, all)
-    # for ip in filter:
-    #     all.discard(ip)
-    #     all.add(IPy.IP(ip.strNormal(0)).make_net('255.255.0.0'))
-
     # 输出结果
-    for ip in all:
+    for ip in china_list_set:
         print '<item>' + str(ip) + '</item>'
 
 

--- a/src/main/assets/pages/about.html
+++ b/src/main/assets/pages/about.html
@@ -274,7 +274,7 @@ img {
 </head>
 <body>
 <p>A <a href="http://shadowsocks.org">Shadowsocks</a> client for Android, written in Scala.</p>
-<p>Copyright (C) 2014 Max Lv <a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#x6d;&#97;x&#46;&#99;.&#108;&#118;&#x40;&#103;&#109;&#97;&#x69;&#108;&#46;&#x63;&#x6f;&#109;">&#x6d;&#97;&#x78;.&#x63;&#x2e;&#108;v&#64;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;</a></p>
+<p>Copyright (C) 2016 Max Lv <a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#x6d;&#97;x&#46;&#99;.&#108;&#118;&#x40;&#103;&#109;&#97;&#x69;&#108;&#46;&#x63;&#x6f;&#109;">&#x6d;&#97;&#x78;.&#x63;&#x2e;&#108;v&#64;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;</a></p>
 <p>This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -289,11 +289,11 @@ along with this program. If not, see <a href="http://www.gnu.org/licenses/">http
 <h3>Open Source Licenses</h3>
 <ul>
     <li>shadowsocks-libev: <a href="https://github.com/shadowsocks/shadowsocks-libev/blob/master/LICENSE">GPLv3</a></li>
-    <li>tun2socks: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/badvpn/COPYING">BSD</a></li>
-    <li>redsocks: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/redsocks/README">APL 2.0</a></li>
-    <li>OpenSSL: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/openssl/NOTICE">OpenSSL</a></li>
+    <li>tun2socks: <a href="https://github.com/shadowsocks/badvpn/blob/shadowsocks-android/COPYING">BSD</a></li>
+    <li>redsocks: <a href="https://github.com/shadowsocks/redsocks/blob/shadowsocks-android/README">APL 2.0</a></li>
+    <li>OpenSSL: <a href="https://github.com/shadowsocks/openssl-android/blob/master/NOTICE">OpenSSL</a></li>
     <li>pdnsd: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/pdnsd/COPYING">GPLv3</a></li>
-    <li>libev: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/libev/LICENSE">GPLv2</a></li>
+    <li>libev: <a href="https://github.com/shadowsocks/libevent/blob/shadowsocks-android/LICENSE">GPLv2</a></li>
     <li>libevent: <a href="https://github.com/shadowsocks/shadowsocks-android/blob/master/src/main/jni/libevent/LICENSE">BSD</a></li>
 </ul>
 

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -45,6 +45,7 @@
     <string-array name="route_entry">
         <item>All</item>
         <item>Bypass LAN</item>
+        <item>Bypass China</item>
         <item>Bypass LAN &amp; China</item>
     </string-array>
 
@@ -52,6 +53,7 @@
         <item>all</item>
         <item>bypass-lan</item>
         <item>bypass-china</item>
+        <item>bypass-lan-china</item>
     </string-array>
 
     <string-array name="private_route">

--- a/src/main/res/values/chnroute.xml
+++ b/src/main/res/values/chnroute.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="chn_route_full">
-        <item>0.0.0.0/8</item>
+    <string-array name="chn_route">
         <item>1.0.1.0/24</item>
         <item>1.0.2.0/23</item>
         <item>1.0.8.0/21</item>
@@ -49,7 +48,6 @@
         <item>1.192.0.0/13</item>
         <item>1.202.0.0/15</item>
         <item>1.204.0.0/14</item>
-        <item>10.0.0.0/8</item>
         <item>14.0.0.0/21</item>
         <item>14.0.12.0/22</item>
         <item>14.1.0.0/22</item>
@@ -771,7 +769,6 @@
         <item>61.236.0.0/15</item>
         <item>61.240.0.0/14</item>
         <item>91.234.36.0/24</item>
-        <item>100.64.0.0/10</item>
         <item>101.0.0.0/22</item>
         <item>101.1.0.0/22</item>
         <item>101.2.172.0/22</item>
@@ -2270,7 +2267,6 @@
         <item>125.215.0.0/18</item>
         <item>125.216.0.0/13</item>
         <item>125.254.128.0/17</item>
-        <item>127.0.0.0/8</item>
         <item>137.59.88.0/22</item>
         <item>139.9.0.0/16</item>
         <item>139.129.0.0/16</item>
@@ -2386,7 +2382,6 @@
         <item>167.189.0.0/16</item>
         <item>167.220.244.0/22</item>
         <item>168.160.0.0/16</item>
-        <item>169.254.0.0/16</item>
         <item>171.8.0.0/13</item>
         <item>171.34.0.0/15</item>
         <item>171.36.0.0/14</item>
@@ -2395,7 +2390,6 @@
         <item>171.104.0.0/13</item>
         <item>171.112.0.0/12</item>
         <item>171.208.0.0/12</item>
-        <item>172.16.0.0/12</item>
         <item>175.0.0.0/12</item>
         <item>175.16.0.0/13</item>
         <item>175.24.0.0/14</item>
@@ -2507,14 +2501,8 @@
         <item>183.182.0.0/19</item>
         <item>183.184.0.0/13</item>
         <item>183.192.0.0/10</item>
-        <item>192.0.0.0/29</item>
-        <item>192.0.2.0/24</item>
-        <item>192.88.99.0/24</item>
         <item>192.124.154.0/24</item>
-        <item>192.168.0.0/16</item>
         <item>192.188.170.0/24</item>
-        <item>198.18.0.0/15</item>
-        <item>198.51.100.0/24</item>
         <item>202.0.100.0/23</item>
         <item>202.0.122.0/23</item>
         <item>202.0.176.0/22</item>
@@ -2910,7 +2898,6 @@
         <item>203.0.90.0/23</item>
         <item>203.0.96.0/23</item>
         <item>203.0.104.0/21</item>
-        <item>203.0.113.0/24</item>
         <item>203.0.114.0/23</item>
         <item>203.0.122.0/24</item>
         <item>203.0.128.0/24</item>

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -44,7 +44,6 @@ import java.lang.Process
 import java.net.{Inet6Address, InetAddress}
 import java.util.Locale
 
-import android.app.Service
 import android.content._
 import android.content.pm.{PackageInfo, PackageManager}
 import android.net.{ConnectivityManager, Network}
@@ -164,12 +163,14 @@ class ShadowsocksNatService extends BaseService {
 
   def startShadowsocksDaemon() {
     if (config.route != Route.ALL) {
-      val acl: Array[String] = config.route match {
-        case Route.BYPASS_LAN => getResources.getStringArray(R.array.private_route)
-        case Route.BYPASS_CHN => getResources.getStringArray(R.array.chn_route_full)
+      val acl: Array[Array[String]] = config.route match {
+        case Route.BYPASS_LAN => Array(getResources.getStringArray(R.array.private_route))
+        case Route.BYPASS_CHN => Array(getResources.getStringArray(R.array.chn_route))
+        case Route.BYPASS_LAN_CHN =>
+          Array(getResources.getStringArray(R.array.private_route), getResources.getStringArray(R.array.chn_route))
       }
       ConfigUtils.printToFile(new File(getApplicationInfo.dataDir + "/acl.list"))(p => {
-        acl.foreach(item => p.println(item))
+        acl.flatten.foreach(p.println)
       })
     }
 

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -273,12 +273,14 @@ class ShadowsocksVpnService extends VpnService with BaseService {
   def startShadowsocksDaemon() {
 
     if (config.route != Route.ALL) {
-      val acl: Array[String] = config.route match {
-        case Route.BYPASS_LAN => getResources.getStringArray(R.array.private_route)
-        case Route.BYPASS_CHN => getResources.getStringArray(R.array.chn_route_full)
+      val acl: Array[Array[String]] = config.route match {
+        case Route.BYPASS_LAN => Array(getResources.getStringArray(R.array.private_route))
+        case Route.BYPASS_CHN => Array(getResources.getStringArray(R.array.chn_route))
+        case Route.BYPASS_LAN_CHN =>
+          Array(getResources.getStringArray(R.array.private_route), getResources.getStringArray(R.array.chn_route))
       }
       ConfigUtils.printToFile(new File(getApplicationInfo.dataDir + "/acl.list"))(p => {
-        acl.foreach(item => p.println(item))
+        acl.flatten.foreach(p.println)
       })
     }
 

--- a/src/main/scala/com/github/shadowsocks/database/DBHelper.scala
+++ b/src/main/scala/com/github/shadowsocks/database/DBHelper.scala
@@ -64,7 +64,7 @@ object DBHelper {
 }
 
 class DBHelper(val context: Context)
-  extends OrmLiteSqliteOpenHelper(context, DBHelper.PROFILE, null, 15) {
+  extends OrmLiteSqliteOpenHelper(context, DBHelper.PROFILE, null, 16) {
   import DBHelper._
 
   lazy val profileDao: Dao[Profile, Int] = getDao(classOf[Profile])
@@ -120,6 +120,10 @@ class DBHelper(val context: Context)
           profileDao.update(profile)
           i += 1
         }
+      }
+
+      if (oldVersion < 16) {
+        profileDao.executeRawNoArgs("UPDATE `profile` SET route = 'bypass-lan-china' WHERE route = 'bypass-china'")
       }
     }
   }

--- a/src/main/scala/com/github/shadowsocks/utils/Constants.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Constants.scala
@@ -110,4 +110,5 @@ object Route {
   val ALL = "all"
   val BYPASS_LAN = "bypass-lan"
   val BYPASS_CHN = "bypass-china"
+  val BYPASS_LAN_CHN = "bypass-lan-china"
 }


### PR DESCRIPTION
Fix #569.

It could have worked without upgrading database by using an option called `bypass-china-only`. But I think we will get better readability this way.