### PR TITLE
Replace Future.onFailure with Future.onComplete

### DIFF
--- a/src/main/scala/com/github/shadowsocks/package.scala
+++ b/src/main/scala/com/github/shadowsocks/package.scala
@@ -2,12 +2,16 @@ package com.github
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.util.{Failure, Try}
 
 /**
   * @author Mygod
   */
 package object shadowsocks {
-  def ThrowableFuture[T](f: => T) = Future(f) onFailure {
-    case e: Throwable => e.printStackTrace()
+
+  val handleFailure: PartialFunction[Try[_], Unit] = {
+    case Failure(e) => e.printStackTrace()
   }
+
+  def ThrowableFuture[T](f: => T) = Future(f) onComplete handleFailure
 }

--- a/src/main/scala/com/github/shadowsocks/package.scala
+++ b/src/main/scala/com/github/shadowsocks/package.scala
@@ -2,7 +2,7 @@ package com.github
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Try}
+import scala.util.{Success, Failure, Try}
 
 /**
   * @author Mygod
@@ -10,6 +10,7 @@ import scala.util.{Failure, Try}
 package object shadowsocks {
 
   val handleFailure: PartialFunction[Try[_], Unit] = {
+    case Success(_) =>
     case Failure(e) => e.printStackTrace()
   }
 


### PR DESCRIPTION
`Future.onFailure` has been deprecated since scala 2.12, let's use `Future.onComplete` instead.

In `scala.concurrent.Future`:
```
  @deprecated("use `onComplete` or `failed.foreach` instead (keep in mind that they take total rather than partial functions)", "2.12")
  def onFailure[U](@deprecatedName('callback) pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Unit = onComplete {
    case Failure(t) =>
      pf.applyOrElse[Throwable, Any](t, Predef.conforms[Throwable]) // Exploiting the cached function to avoid MatchError
    case _ =>
  }
```