### PR TITLE
Fix binder ipc issue when process died unexpected

### DIFF
--- a/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
+++ b/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
@@ -377,7 +377,11 @@ class Shadowsocks
     })
     updateTraffic(0, 0, 0, 0)
 
-    // Bind to the service
+    bindToService()
+  }
+
+  // Bind to the service
+  def bindToService() {
     handler.post(() => attachService)
   }
 

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksDeathRecipient.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksDeathRecipient.scala
@@ -1,0 +1,28 @@
+package com.github.shadowsocks
+
+import android.os.IBinder
+import android.util.Log
+import com.github.shadowsocks.utils.ProcessUtils._
+
+/**
+  * @author chentaov5@gmail.com
+  */
+class ShadowsocksDeathRecipient(val mContext: ServiceBoundContext)
+  extends IBinder.DeathRecipient {
+
+  val TAG = "ShadowsocksDeathRecipient"
+
+  override def binderDied(): Unit = {
+    Log.d(TAG, "[ShadowsocksDeathRecipient] binder died.")
+
+    mContext match {
+      case ss: Shadowsocks =>
+        inShadowsocks {
+          ss.unregisterCallback
+          ss.bindToService()
+        }
+      case _ =>
+    }
+  }
+
+}

--- a/src/main/scala/com/github/shadowsocks/utils/IOUtils.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/IOUtils.scala
@@ -1,0 +1,33 @@
+package com.github.shadowsocks.utils
+
+import android.util.Log
+
+/**
+  * @author chentaov5@gmail.com
+  */
+object IOUtils {
+
+  val TAG = "IOUtils"
+
+  def autoClose[R <: {def close() : Unit}, T](in: R)(fun: => T): T = {
+    try {
+      fun
+    } finally if (in ne null)
+      try {
+        in.close()
+      } catch {
+        case e: Exception => Log.d(TAG, e.getMessage, e)
+      }
+  }
+
+  def inSafe[T](fun: => T): Option[T] = {
+    var res: Option[T] = None
+    try {
+      res = Some(fun)
+    } catch {
+      case e: Exception => Log.d(TAG, e.getMessage, e)
+    }
+    res
+  }
+
+}

--- a/src/main/scala/com/github/shadowsocks/utils/ProcessUtils.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/ProcessUtils.scala
@@ -1,0 +1,46 @@
+package com.github.shadowsocks.utils
+
+import java.io.{BufferedReader, FileInputStream, InputStreamReader}
+
+import com.github.shadowsocks.utils.IOUtils._
+
+/**
+  * @author chentaov5@gmail.com
+  */
+object ProcessUtils {
+
+  val SHADOWNSOCKS     = "com.github.shadowsocks"
+  val SHADOWNSOCKS_VPN = "com.github.shadowsocks:vpn"
+  val SHADOWNSOCKS_NAT = "com.github.shadowsocks:nat"
+  val TUN2SOCKS        = "/data/data/com.github.shadowsocks/tun2socks"
+  val SS_LOCAL         = "/data/data/com.github.shadowsocks/ss-local"
+  val SS_TUNNEL        = "/data/data/com.github.shadowsocks/ss-tunnel"
+  val PDNSD            = "/data/data/com.github.shadowsocks/pdnsd"
+
+  def getCurrentProcessName: String = {
+    inSafe {
+      val inputStream = new FileInputStream("/proc/self/cmdline")
+      val reader = new BufferedReader(new InputStreamReader(inputStream))
+      autoClose(reader) {
+        reader.readLine() match {
+          case name: String => name
+          case _ => ""
+        }
+      }
+    } match {
+      case Some(name: String) => name
+      case None => ""
+    }
+  }
+
+  def inShadowsocks[A](fun: => A): Unit =
+    if(getCurrentProcessName startsWith SHADOWNSOCKS) fun
+
+  def inVpn[A](fun: => A): Unit =
+    if (getCurrentProcessName startsWith SHADOWNSOCKS_VPN) fun
+
+
+  def inNat[A](fun: => A): Unit =
+    if (getCurrentProcessName startsWith SHADOWNSOCKS_NAT) fun
+
+}


### PR DESCRIPTION
If **shadowsocks:vpn** died unexpected, such as:

```bash
> adb shell ps | grep shadowsocks
u0_a52    1456  141   537172 40864 ffffffff b754e7ca S com.github.shadowsocks
u0_a52    1477  141   523808 32712 ffffffff b754ff37 S com.github.shadowsocks:vpn
u0_a52    1523  1477  6980   1424  c01d7f5f b7df5f37 S /data/data/com.github.shadowsocks/ss-local
u0_a52    1524  1477  8508   1236  ffffffff b7df577f S /data/data/com.github.shadowsocks/pdnsd
u0_a52    1525  1477  6960   1420  c01d7f5f b7df5f37 S /data/data/com.github.shadowsocks/ss-tunnel
u0_a52    1533  1477  6488   1180  c01d7f5f b7df5f37 S /data/data/com.github.shadowsocks/tun2socks
```

```bash
> adb shell kill 1477
```

We'll find **shadowsocks** won't respond to `trafficUpdated` or `stateChanged` no matter how many times we click on `FloatingActionButton`, because `bgService` in **shadowsocks** don't work since binder **died**. 

Though **shadowsocks:vpn** will restart immediately, **shadowsocks:vpn** can't send msg through binder ipc to **shadowsocks** without `bgService.registerCallback(callback)`, so I did something to fix:

1. registered `ShadowsocksDeathRecipient` to `bgService`.
2. let **shadowsocks** re-bind to `ShadowsocksVpnService`(or `ShadowsocksNatService`) when `binderDied` called.

And it works fine now.  :yum: 