### PR TITLE
Automatic service restart (with zero latency) after switching profile

### DIFF
--- a/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksService.aidl
+++ b/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksService.aidl
@@ -10,6 +10,5 @@ interface IShadowsocksService {
   oneway void registerCallback(IShadowsocksServiceCallback cb);
   oneway void unregisterCallback(IShadowsocksServiceCallback cb);
 
-  oneway void start(in Config config);
-  oneway void stop();
+  oneway void use(in Config config);
 }

--- a/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
+++ b/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
@@ -328,7 +328,7 @@ class Shadowsocks
           handler.post(() => onActivityResult(Shadowsocks.REQUEST_CONNECT, Activity.RESULT_OK, null))
         }
       } else {
-        serviceStart()
+        serviceLoad()
       }
     }
   }
@@ -367,21 +367,6 @@ class Shadowsocks
     updateTraffic(0, 0, 0, 0)
 
     handler.post(() => attachService)
-  }
-
-  def reloadProfile() {
-    currentProfile = ShadowsocksApplication.currentProfile match {
-      case Some(profile) => profile // updated
-      case None =>                  // removed
-        ShadowsocksApplication.profileManager.getFirstProfile match {
-          case Some(first) => ShadowsocksApplication.switchProfile(first.id)
-          case None => ShadowsocksApplication.profileManager.createDefault()
-        }
-    }
-
-    updatePreferenceScreen()
-
-    serviceStop()
   }
 
   protected override def onPause() {
@@ -434,7 +419,20 @@ class Shadowsocks
     ConfigUtils.refresh(this)
 
     // Check if current profile changed
-    if (ShadowsocksApplication.profileId != currentProfile.id) reloadProfile()
+    if (ShadowsocksApplication.profileId != currentProfile.id) {
+      currentProfile = ShadowsocksApplication.currentProfile match {
+        case Some(profile) => profile // updated
+        case None =>                  // removed
+          ShadowsocksApplication.profileManager.getFirstProfile match {
+            case Some(first) => ShadowsocksApplication.switchProfile(first.id)
+            case None => ShadowsocksApplication.profileManager.createDefault()
+          }
+      }
+
+      updatePreferenceScreen()
+
+      if (serviceStarted) serviceLoad()
+    }
 
     updateState()
   }
@@ -485,7 +483,7 @@ class Shadowsocks
   }
 
   def recovery() {
-    serviceStop()
+    if (serviceStarted) serviceStop()
     val h = showProgress(R.string.recovering)
     ThrowableFuture {
       reset()
@@ -504,14 +502,14 @@ class Shadowsocks
 
   override def onActivityResult(requestCode: Int, resultCode: Int, data: Intent) = resultCode match {
     case Activity.RESULT_OK =>
-      serviceStart()
+      serviceLoad()
     case _ =>
       cancelStart()
       Log.e(Shadowsocks.TAG, "Failed to start VpnService")
   }
 
   def serviceStop() {
-    if (bgService != null) bgService.stop()
+    if (bgService != null) bgService.use(null)
   }
 
   def checkText(key: String): Boolean = {
@@ -522,8 +520,8 @@ class Shadowsocks
   }
 
   /** Called when connect button is clicked. */
-  def serviceStart() {
-    bgService.start(ConfigUtils.load(ShadowsocksApplication.settings))
+  def serviceLoad() {
+    bgService.use(ConfigUtils.load(ShadowsocksApplication.settings))
 
     if (ShadowsocksApplication.isVpnEnabled) {
       changeSwitch(checked = false)

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -49,7 +49,6 @@ import android.content.pm.{PackageInfo, PackageManager}
 import android.net.{ConnectivityManager, Network}
 import android.os._
 import android.util.{Log, SparseArray}
-import android.widget.Toast
 import com.github.shadowsocks.aidl.Config
 import com.github.shadowsocks.utils._
 
@@ -65,7 +64,6 @@ class ShadowsocksNatService extends BaseService {
     "-j DNAT --to-destination 127.0.0.1:8123"
 
   private var notification: ShadowsocksNotification = _
-  var closeReceiver: BroadcastReceiver = _
   var connReceiver: BroadcastReceiver = _
   val myUid = android.os.Process.myUid()
 
@@ -386,16 +384,6 @@ class ShadowsocksNatService extends BaseService {
     }
     super.startRunner(config)
 
-    // register close receiver
-    val filter = new IntentFilter()
-    filter.addAction(Intent.ACTION_SHUTDOWN)
-    filter.addAction(Action.CLOSE)
-    closeReceiver = (context: Context, intent: Intent) => {
-      Toast.makeText(context, R.string.stopping, Toast.LENGTH_SHORT).show()
-      stopRunner()
-    }
-    registerReceiver(closeReceiver, filter)
-
     ShadowsocksApplication.track(TAG, "start")
     
     changeState(State.CONNECTING)
@@ -449,12 +437,6 @@ class ShadowsocksNatService extends BaseService {
 
     // channge the state
     changeState(State.STOPPING)
-
-    // clean up recevier
-    if (closeReceiver != null) {
-      unregisterReceiver(closeReceiver)
-      closeReceiver = null
-    }
 
     if (notification != null) notification.destroy()
 

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksQuickSwitchActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksQuickSwitchActivity.scala
@@ -1,9 +1,9 @@
 package com.github.shadowsocks
 
 import android.content.res.Resources
-import android.os.{Handler, Build, Bundle}
+import android.os.{Build, Bundle}
 import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.{Toolbar, DefaultItemAnimator, LinearLayoutManager, RecyclerView}
+import android.support.v7.widget.{DefaultItemAnimator, LinearLayoutManager, RecyclerView, Toolbar}
 import android.view.{LayoutInflater, View, ViewGroup}
 import android.widget.CheckedTextView
 import com.github.shadowsocks.database.Profile
@@ -31,12 +31,8 @@ class ShadowsocksQuickSwitchActivity extends AppCompatActivity {
     }
 
     def onClick(v: View) {
-      Utils.stopSsService(ShadowsocksQuickSwitchActivity.this)
       ShadowsocksApplication.switchProfile(item.id)
-      val handler = new Handler(ShadowsocksQuickSwitchActivity.this.getMainLooper)
-      handler.postDelayed(() => {
-        Utils.startSsService(ShadowsocksQuickSwitchActivity.this)
-      }, 3000)
+      Utils.startSsService(ShadowsocksQuickSwitchActivity.this)
       finish
     }
   }

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksRunnerActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksRunnerActivity.scala
@@ -65,7 +65,7 @@ class ShadowsocksRunnerActivity extends Activity with ServiceBoundContext {
         onActivityResult(Shadowsocks.REQUEST_CONNECT, Activity.RESULT_OK, null)
       }
     } else {
-      bgService.start(ConfigUtils.load(ShadowsocksApplication.settings))
+      bgService.use(ConfigUtils.load(ShadowsocksApplication.settings))
       finish()
     }
   }
@@ -101,7 +101,7 @@ class ShadowsocksRunnerActivity extends Activity with ServiceBoundContext {
     resultCode match {
       case Activity.RESULT_OK =>
         if (bgService != null) {
-          bgService.start(ConfigUtils.load(ShadowsocksApplication.settings))
+          bgService.use(ConfigUtils.load(ShadowsocksApplication.settings))
         }
       case _ =>
         Log.e(Shadowsocks.TAG, "Failed to start VpnService")

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksRunnerService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksRunnerService.scala
@@ -61,11 +61,11 @@ class ShadowsocksRunnerService extends Service with ServiceBoundContext {
       val intent = VpnService.prepare(ShadowsocksRunnerService.this)
       if (intent == null) {
         if (bgService != null) {
-          bgService.start(ConfigUtils.load(ShadowsocksApplication.settings))
+          bgService.use(ConfigUtils.load(ShadowsocksApplication.settings))
         }
       }
     } else {
-      bgService.start(ConfigUtils.load(ShadowsocksApplication.settings))
+      bgService.use(ConfigUtils.load(ShadowsocksApplication.settings))
     }
     stopSelf()
   }

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -49,7 +49,6 @@ import android.content.pm.{PackageInfo, PackageManager}
 import android.net.VpnService
 import android.os._
 import android.util.Log
-import android.widget.Toast
 import com.github.shadowsocks.aidl.Config
 import com.github.shadowsocks.utils._
 import org.apache.commons.net.util.SubnetUtils
@@ -64,7 +63,6 @@ class ShadowsocksVpnService extends VpnService with BaseService {
   var conn: ParcelFileDescriptor = _
   var vpnThread: ShadowsocksVpnThread = _
   private var notification: ShadowsocksNotification = _
-  var closeReceiver: BroadcastReceiver = _
 
   var sslocalProcess: Process = _
   var sstunnelProcess: Process = _
@@ -134,12 +132,6 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       conn = null
     }
 
-    // clean up recevier
-    if (closeReceiver != null) {
-      unregisterReceiver(closeReceiver)
-      closeReceiver = null
-    }
-
     super.stopRunner()
   }
 
@@ -180,16 +172,6 @@ class ShadowsocksVpnService extends VpnService with BaseService {
 
     vpnThread = new ShadowsocksVpnThread(this)
     vpnThread.start()
-
-    // register close receiver
-    val filter = new IntentFilter()
-    filter.addAction(Intent.ACTION_SHUTDOWN)
-    filter.addAction(Action.CLOSE)
-    closeReceiver = (context: Context, intent: Intent) => {
-      Toast.makeText(context, R.string.stopping, Toast.LENGTH_SHORT).show()
-      stopRunner()
-    }
-    registerReceiver(closeReceiver, filter)
 
     // ensure the VPNService is prepared
     if (VpnService.prepare(this) != null) {

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnThread.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnThread.scala
@@ -66,7 +66,7 @@ class ShadowsocksVpnThread(vpnService: ShadowsocksVpnService) extends Thread {
         case _: Exception => // ignore
       }
       serverSocket = null
-      }
+    }
   }
 
   def stopThread() {

--- a/src/main/scala/com/github/shadowsocks/TaskerReceiver.scala
+++ b/src/main/scala/com/github/shadowsocks/TaskerReceiver.scala
@@ -39,7 +39,6 @@
 package com.github.shadowsocks
 
 import android.content.{BroadcastReceiver, Context, Intent}
-import android.os.Handler
 import com.github.shadowsocks.helper.TaskerSettings
 import com.github.shadowsocks.utils.Utils
 
@@ -51,15 +50,10 @@ class TaskerReceiver extends BroadcastReceiver {
     val settings = TaskerSettings.fromIntent(intent)
     val switched = ShadowsocksApplication.profileManager.getProfile(settings.profileId) match {
       case Some(p) =>
-        Utils.stopSsService(context)
         ShadowsocksApplication.switchProfile(settings.profileId)
         true
       case _ => false
     }
-    val handler = new Handler(context.getMainLooper)
-    handler.postDelayed(() => {
-        if (settings.switchOn) Utils.startSsService(context)
-        else if (!switched) Utils.stopSsService(context)
-      }, 3000)
+    if (settings.switchOn) Utils.startSsService(context) else Utils.stopSsService(context)
   }
 }

--- a/src/main/scala/com/github/shadowsocks/utils/Constants.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Constants.scala
@@ -72,8 +72,8 @@ object Key {
   val isProxyApps = "isProxyApps"
   val isBypassApps = "isBypassApps"
   val isUdpDns = "isUdpDns"
-  val isAuth= "isAuth"
-  val isIpv6= "isIpv6"
+  val isAuth = "isAuth"
+  val isIpv6 = "isIpv6"
 
   val proxy = "proxy"
   val sitekey = "sitekey"

--- a/src/main/scala/com/github/shadowsocks/utils/TrafficMonitor.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/TrafficMonitor.scala
@@ -1,6 +1,5 @@
 package com.github.shadowsocks.utils
 
-import java.lang.System
 import java.text.DecimalFormat
 
 import com.github.shadowsocks.{R, ShadowsocksApplication}
@@ -81,4 +80,3 @@ object TrafficMonitor {
     dirty = true
   }
 }
-

--- a/src/main/scala/com/github/shadowsocks/utils/Utils.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Utils.scala
@@ -42,7 +42,7 @@ import java.io._
 import java.net._
 import java.security.MessageDigest
 
-import android.animation.{AnimatorListenerAdapter, Animator}
+import android.animation.{Animator, AnimatorListenerAdapter}
 import android.app.ActivityManager
 import android.content.pm.{ApplicationInfo, PackageManager}
 import android.content.{Context, Intent}
@@ -51,11 +51,11 @@ import android.graphics.drawable.{BitmapDrawable, Drawable}
 import android.os.Build
 import android.provider.Settings
 import android.support.v4.content.ContextCompat
-import android.util.{DisplayMetrics, Base64, Log}
+import android.util.{Base64, DisplayMetrics, Log}
 import android.view.View.MeasureSpec
 import android.view.{Gravity, View, Window}
 import android.widget.Toast
-import com.github.shadowsocks.{ShadowsocksRunnerService, ShadowsocksApplication, BuildConfig}
+import com.github.shadowsocks.{BuildConfig, ShadowsocksApplication, ShadowsocksRunnerService}
 import org.xbill.DNS._
 
 
@@ -401,7 +401,7 @@ object Utils {
     }
   }
 
-  def startSsService(context: Context): Unit = {
+  def startSsService(context: Context) {
     val isInstalled: Boolean = ShadowsocksApplication.settings.getBoolean(ShadowsocksApplication.getVersionName, false)
     if (!isInstalled) return
 
@@ -409,8 +409,9 @@ object Utils {
     context.startService(intent)
   }
 
-  def stopSsService(context: Context): Unit = {
-    context.sendBroadcast(new Intent(Action.CLOSE))
+  def stopSsService(context: Context) {
+    val intent = new Intent(Action.CLOSE)
+    context.sendBroadcast(intent)
   }
 }
 


### PR DESCRIPTION
`start(Config)` and `stop()` has been replaced by `use(Config)` and `use(null)` to implement this feature. Invoking `start(Config)` with a different config will restart the service.

## A possible issue/race condition

There are three ways to switch profiles which is when service restart is required:

1. via Profile selector.
2. via Tasker.
3. via Quick Switch introduced in #598.

When the latter two are performed and `Shadowsocks` is resumed, it will sometimes start the service twice and after a chain of events it results in `Unable to connect to remote server` so the service stops itself.