### PR TITLE
Add support for Android TV

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-feature
             android:name="android.hardware.touchscreen"
             android:required="false"/>
+    <uses-feature android:name="android.software.leanback"
+                  android:required="false" />
 
     <uses-feature android:name="android.hardware.nfc" android:required="false" />
 
@@ -25,7 +27,8 @@
             android:icon="@drawable/ic_launcher"
             android:backupAgent=".ShadowsocksBackupAgent"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Material">
+            android:theme="@style/Theme.Material"
+            android:banner="@drawable/ic_start_connected">
 
         <meta-data android:name="com.google.android.gms.version"
                    android:value="@integer/google_play_services_version"/>
@@ -43,6 +46,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
             </intent-filter>
         </activity>
 

--- a/src/main/res/layout/layout_apps.xml
+++ b/src/main/res/layout/layout_apps.xml
@@ -45,7 +45,7 @@
                  android:layout_width="wrap_content"
                  android:layout_height="wrap_content"
                  android:layout_gravity="center" />
-    <ListView
+    <android.support.v7.widget.RecyclerView
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:id="@+id/applistview"

--- a/src/main/res/layout/layout_apps_item.xml
+++ b/src/main/res/layout/layout_apps_item.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:background="?android:attr/selectableItemBackground">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:focusable="true"
+              android:background="?android:attr/selectableItemBackground">
 
     <ImageView
         android:id="@+id/itemicon"
@@ -15,20 +16,19 @@
         android:paddingTop="2dp"
         android:paddingBottom="2dp"/>
 
-    <TextView
-        android:id="@+id/itemtext"
+    <Switch
+        android:id="@+id/itemcheck"
         android:layout_width="0dp"
         android:layout_weight="1"
         android:layout_height="fill_parent"
         android:gravity="center_vertical"
         android:ellipsize="end"
-        android:textSize="18sp"/>
-
-    <Switch
-        android:id="@+id/itemcheck"
-        android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
-        android:layout_marginLeft="8dp"
+        android:textSize="18sp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:clickable="false"
+        android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"/>
 
 </LinearLayout>

--- a/src/main/res/layout/layout_profiles_item.xml
+++ b/src/main/res/layout/layout_profiles_item.xml
@@ -3,11 +3,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+              android:id="@+id/container"
               android:background="?android:attr/selectableItemBackground"
               android:paddingStart="20dp"
               android:paddingEnd="?attr/dialogPreferredPadding"
               android:paddingLeft="20dp"
-              android:paddingRight="?attr/dialogPreferredPadding">
+              android:paddingRight="?attr/dialogPreferredPadding"
+              android:focusable="true"
+              android:nextFocusRight="@+id/share">
     <CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
                      android:id="@android:id/text1"
                      android:layout_width="0dp"
@@ -30,5 +33,7 @@
                android:layout_gravity="center_vertical"
                android:src="@drawable/ic_social_share"
                android:background="?attr/selectableItemBackgroundBorderless"
-               android:contentDescription="@string/share"/>
+               android:contentDescription="@string/share"
+               android:focusable="true"
+               android:nextFocusLeft="@+id/container"/>
 </LinearLayout>

--- a/src/main/res/layout/overlay.xml
+++ b/src/main/res/layout/overlay.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="80dp" android:maxWidth="80dp" android:gravity="center"
-    android:textSize="70sp" android:textColor="#ffffffff"
-    android:background="#99000088" android:padding="10dp"
-    android:visibility="invisible"/>

--- a/src/main/res/values-zh-rCN/strings.xml
+++ b/src/main/res/values-zh-rCN/strings.xml
@@ -89,7 +89,7 @@
 
   <!-- profile -->
   <string name="profile_manager_dialog">配置文件</string>
-  <string name="profile_manager_dialog_content">&#8226; 点击选择配置文件；\n&#8226; 滑动删除；\n&#8226;
+  <string name="profile_manager_dialog_content">&#8226; 点击选择配置文件；\n&#8226; 向左/右滑动或按左删除；\n&#8226;
     长按拖动改变顺序。</string>
   <string name="gotcha">好的</string>
   <string name="copy_url">复制 URL</string>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -90,7 +90,7 @@
 
   <!-- profile -->
   <string name="profile_manager_dialog">設定檔</string>
-  <string name="profile_manager_dialog_content">&#8226; 輕觸選擇一個設定檔；\n&#8226; 向右撥動移除；\n&#8226;
+  <string name="profile_manager_dialog_content">&#8226; 輕觸選擇一個設定檔；\n&#8226; 向左/右撥動或按左移除；\n&#8226;
     按住後上下撥動設定檔重新排序。</string>
   <string name="gotcha">我懂了！</string>
   <string name="copy_url">複製 URL</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -110,8 +110,8 @@
 
   <!-- profile -->
   <string name="profile_manager_dialog">Profiles</string>
-  <string name="profile_manager_dialog_content">&#8226; Tap to select a profile;\n&#8226; Swipe to remove;\n&#8226;
-    Long press to reorder profiles.</string>
+  <string name="profile_manager_dialog_content">&#8226; Tap to select a profile;\n&#8226; Swipe left/right or press left
+    to remove;\n&#8226; Long press to reorder profiles.</string>
   <string name="gotcha">Gotcha!</string>
   <string name="add_profile_dialog">Add this Shadowsocks Profile?</string>
   <string name="add_profile_methods_scan_qr_code">Scan QR code</string>

--- a/src/main/scala/com/github/shadowsocks/ProfileManagerActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/ProfileManagerActivity.scala
@@ -15,9 +15,9 @@ import android.support.v7.widget.helper.ItemTouchHelper.SimpleCallback
 import android.support.v7.widget.{DefaultItemAnimator, LinearLayoutManager, RecyclerView, Toolbar}
 import android.text.style.TextAppearanceSpan
 import android.text.{SpannableStringBuilder, Spanned, TextUtils}
-import android.view.{LayoutInflater, MenuItem, View, ViewGroup}
+import android.view._
 import android.widget.{CheckedTextView, ImageView, LinearLayout, Toast}
-import com.github.clans.fab.{FloatingActionMenu, FloatingActionButton}
+import com.github.clans.fab.{FloatingActionButton, FloatingActionMenu}
 import com.github.shadowsocks.aidl.IShadowsocksServiceCallback
 import com.github.shadowsocks.database.Profile
 import com.github.shadowsocks.utils.{Key, Parser, TrafficMonitor, Utils}
@@ -27,12 +27,14 @@ import net.glxn.qrgen.android.QRCode
 
 import scala.collection.mutable.ArrayBuffer
 
-class ProfileManagerActivity extends AppCompatActivity with OnMenuItemClickListener with ServiceBoundContext with View.OnClickListener
-  with CreateNdefMessageCallback {
-  private class ProfileViewHolder(val view: View) extends RecyclerView.ViewHolder(view) with View.OnClickListener {
+final class ProfileManagerActivity extends AppCompatActivity with OnMenuItemClickListener with ServiceBoundContext
+  with View.OnClickListener with CreateNdefMessageCallback {
+  private final class ProfileViewHolder(val view: View) extends RecyclerView.ViewHolder(view)
+    with View.OnClickListener with View.OnKeyListener {
     var item: Profile = _
     private val text = itemView.findViewById(android.R.id.text1).asInstanceOf[CheckedTextView]
     itemView.setOnClickListener(this)
+    itemView.setOnKeyListener(this)
 
     {
       val shareBtn = itemView.findViewById(R.id.share)
@@ -107,6 +109,15 @@ class ProfileManagerActivity extends AppCompatActivity with OnMenuItemClickListe
       ShadowsocksApplication.switchProfile(item.id)
       finish
     }
+
+    def onKey(v: View, keyCode: Int, event: KeyEvent) = if (event.getAction == KeyEvent.ACTION_UP) keyCode match {
+      case KeyEvent.KEYCODE_DPAD_LEFT =>
+        val index = getAdapterPosition
+        profilesAdapter.remove(index)
+        undoManager.remove(index, item)
+        true
+      case _ => false
+    } else false
   }
 
   private class ProfilesAdapter extends RecyclerView.Adapter[ProfileViewHolder] {

--- a/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
+++ b/src/main/scala/com/github/shadowsocks/Shadowsocks.scala
@@ -134,9 +134,9 @@ class Shadowsocks
             preferences.setEnabled(false)
             stat.setVisibility(View.VISIBLE)
             if (ShadowsocksApplication.isVpnEnabled) {
-              connectionTest.setVisibility(View.VISIBLE)
-              connectionTest.setText(getString(R.string.connection_test_pending))
-            } else connectionTest.setVisibility(View.GONE)
+              connectionTestText.setVisibility(View.VISIBLE)
+              connectionTestText.setText(getString(R.string.connection_test_pending))
+            } else connectionTestText.setVisibility(View.GONE)
           case State.STOPPED =>
             fab.setBackgroundTintList(greyTint)
             fabProgressCircle.postDelayed(hideCircle, 1000)
@@ -217,7 +217,7 @@ class Shadowsocks
 
   private var testCount: Int = _
   private lazy val stat = findViewById(R.id.stat)
-  private lazy val connectionTest = findViewById(R.id.connection_test).asInstanceOf[TextView]
+  private var connectionTestText: TextView = _
   private var txText: TextView = _
   private var rxText: TextView = _
   private var txRateText: TextView = _
@@ -371,6 +371,7 @@ class Shadowsocks
     val field = classOf[Toolbar].getDeclaredField("mTitleTextView")
     field.setAccessible(true)
     val title = field.get(toolbar).asInstanceOf[TextView]
+    title.setFocusable(true)
     title.setOnClickListener(_ => startActivity(new Intent(this, classOf[ProfileManagerActivity])))
     val typedArray = obtainStyledAttributes(Array(R.attr.selectableItemBackgroundBorderless))
     title.setBackgroundResource(typedArray.getResourceId(0, 0))
@@ -378,11 +379,12 @@ class Shadowsocks
     val tf = Typefaces.get(this, "fonts/Iceland.ttf")
     if (tf != null) title.setTypeface(tf)
 
-    val connectionTestText = findViewById(R.id.connection_test).asInstanceOf[TextView]
+    connectionTestText = findViewById(R.id.connection_test).asInstanceOf[TextView]
     txText = findViewById(R.id.tx).asInstanceOf[TextView]
     txRateText = findViewById(R.id.txRate).asInstanceOf[TextView]
     rxText = findViewById(R.id.rx).asInstanceOf[TextView]
     rxRateText = findViewById(R.id.rxRate).asInstanceOf[TextView]
+    connectionTestText.setFocusable(true)
     connectionTestText.setOnClickListener(_ => {
       val id = synchronized {
         testCount += 1
@@ -472,9 +474,9 @@ class Shadowsocks
           fabProgressCircle.postDelayed(hideCircle, 100)
           stat.setVisibility(View.VISIBLE)
           if (ShadowsocksApplication.isVpnEnabled) {
-            connectionTest.setVisibility(View.VISIBLE)
-            connectionTest.setText(getString(R.string.connection_test_pending))
-          } else connectionTest.setVisibility(View.GONE)
+            connectionTestText.setVisibility(View.VISIBLE)
+            connectionTestText.setText(getString(R.string.connection_test_pending))
+          } else connectionTestText.setVisibility(View.GONE)
         case State.STOPPING =>
           fab.setBackgroundTintList(greyTint)
           serviceStarted = false


### PR DESCRIPTION
This commit adds an app banner in Android TV and introduces several changes including refactoring AppManager to make all features accessible with D-pad navigation.

Currently this app has the exact same user interface on Android TV as on normal Android devices but one should create a TV-specific user interface in the future.

P.S. Only tested in Android emulator. More testing might be needed.

Screenshots attached.

![screenshot_20160416-110908](https://cloud.githubusercontent.com/assets/3511321/14578810/adec5d52-03c5-11e6-87e0-c76ab0c89957.png)
![screenshot_20160416-111533](https://cloud.githubusercontent.com/assets/3511321/14578809/adec15ea-03c5-11e6-95df-380986eda759.png)
![screenshot_20160416-111615](https://cloud.githubusercontent.com/assets/3511321/14578811/adec65e0-03c5-11e6-9d9c-aa16da616c4a.png)
