### PR TITLE
add a perl script to generate chnroute

### DIFF
--- a/gfwlist/gen.pl
+++ b/gfwlist/gen.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+## ArchLinux install package via pacman: perl-net-cidr-lite
+use strict;
+use warnings;
+use Net::CIDR::Lite;
+my $cidr = Net::CIDR::Lite->new;
+while (my $line=<>) {
+    $cidr->add($line);
+}
+foreach my $line( @{$cidr->list} ) {
+    print "<item>$line</item>\n";
+}


### PR DESCRIPTION
The perl version takes two seconds while the python version takes more than 30 seconds

Usage: perl ./gen.pl < chnroute.txt > chnroute-merged.txt

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>