### PR TITLE
Drop redundant rule

### DIFF
--- a/src/main/jni/Android.mk
+++ b/src/main/jni/Android.mk
@@ -559,8 +559,6 @@ MBEDTLS_SOURCES  := $(wildcard $(LOCAL_PATH)/mbedtls/library/*.c)
 
 LOCAL_SRC_FILES := $(MBEDTLS_SOURCES:$(LOCAL_PATH)/%=%)
 
-LOCAL_LDLIBS := -ldl -llog
-
 include $(BUILD_STATIC_LIBRARY)
 
 # Import cpufeatures


### PR DESCRIPTION
[info] Android NDK: WARNING:jni/Android.mk:mbedtls: LOCAL_LDLIBS is always ignored for static libraries