### PR TITLE
fix compile error caused by new api lint

### DIFF
--- a/src/main/scala/com/github/shadowsocks/QuickToggleShortcut.scala
+++ b/src/main/scala/com/github/shadowsocks/QuickToggleShortcut.scala
@@ -1,5 +1,6 @@
 package com.github.shadowsocks
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ShortcutManager
@@ -10,6 +11,7 @@ import com.github.shadowsocks.utils.{State, Utils}
   * @author Mygod
   */
 class QuickToggleShortcut extends Activity with ServiceBoundContext {
+  @SuppressLint(Array("NewApi"))
   override def onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     getIntent.getAction match {

--- a/src/main/scala/com/github/shadowsocks/ScannerActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/ScannerActivity.scala
@@ -1,5 +1,6 @@
 package com.github.shadowsocks
 
+import android.annotation.SuppressLint
 import android.app.{Activity, TaskStackBuilder}
 import android.content.Intent
 import android.content.pm.{PackageManager, ShortcutManager}
@@ -43,6 +44,7 @@ class ScannerActivity extends AppCompatActivity with ZXingScannerView.ResultHand
     else finish()
   }
 
+  @SuppressLint(Array("NewApi"))
   override def onCreate(state: Bundle) {
     super.onCreate(state)
     setContentView(R.layout.layout_scanner)

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
@@ -110,6 +110,7 @@ class ShadowsocksApplication extends Application {
     profileManager.getProfile(id) getOrElse profileManager.createProfile()
   }
 
+  @SuppressLint(Array("NewApi"))
   private def checkChineseLocale(locale: Locale): Locale = if (locale.getLanguage == "zh") locale.getCountry match {
     case "CN" | "TW" => null            // already supported
     case _ => locale.getScript match {  // fallback to the corresponding script

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksQuickSwitchActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksQuickSwitchActivity.scala
@@ -1,5 +1,6 @@
 package com.github.shadowsocks
 
+import android.annotation.SuppressLint
 import android.content.pm.ShortcutManager
 import android.content.res.Resources
 import android.os.{Build, Bundle}
@@ -56,6 +57,7 @@ class ShadowsocksQuickSwitchActivity extends AppCompatActivity {
 
   private val profilesAdapter = new ProfilesAdapter
 
+  @SuppressLint(Array("NewApi"))
   override def onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.layout_quick_switch)


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ x ] Bugfix

### Details


I can't build the last commit f48ad61220a63f2d54c3aca757cf252eedb89110 by command `sbt compile` on my Mac. It prompt the following error:
```
[error] [NewApi] target/android/intermediates/classes/com/github/shadowsocks/QuickToggleShortcut.class:Class requires API level 25 (current min is 19): android.content.pm.ShortcutManager
[error] [NewApi] target/android/intermediates/classes/com/github/shadowsocks/ScannerActivity.class:Class requires API level 25 (current min is 19): android.content.pm.ShortcutManager
[error] [NewApi] target/android/intermediates/classes/com/github/shadowsocks/ShadowsocksApplication.class:Call requires API level 21 (current min is 19): java.util.Locale#getScript
[error] [NewApi] target/android/intermediates/classes/com/github/shadowsocks/ShadowsocksApplication.class:Call requires API level 21 (current min is 19): java.util.Locale#toLanguageTag
[error] [NewApi] target/android/intermediates/classes/com/github/shadowsocks/ShadowsocksQuickSwitchActivity.class:Class requires API level 25 (current min is 19): android.content.pm.ShortcutManager

```

This patch fix the compile errors.

