### PR TITLE
Let Android system extract native libraries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,19 +7,9 @@ function try () {
 # Build native binaries
 pushd src/main
 try $ANDROID_NDK_HOME/ndk-build -j8
-
+# Clean up old binaries (no longer used)
 rm -rf assets/armeabi-v7a
 rm -rf assets/x86
-mkdir -p assets/armeabi-v7a
-mkdir -p assets/x86
-
-#copy executables
-for app in pdnsd redsocks ss-local ss-tunnel tun2socks
-do
-    echo $app
-    try mv libs/armeabi-v7a/$app assets/armeabi-v7a/
-    try mv libs/x86/$app assets/x86/
-done
 popd
 
 # Build kcptun

--- a/kcptun/make.bash
+++ b/kcptun/make.bash
@@ -58,12 +58,12 @@ go get
 echo "Cross compile kcptun for arm"
 try env CGO_ENABLED=1 CC=$ANDROID_ARM_CC GOOS=android GOARCH=arm GOARM=7 go build -ldflags="-s -w"
 try $ANDROID_ARM_STRIP client
-try mv client $DIR/../src/main/assets/armeabi-v7a/kcptun
+try mv client $DIR/../src/main/libs/armeabi-v7a/libkcptun.so
 
 echo "Cross compile kcptun for x86"
 try env CGO_ENABLED=1 CC=$ANDROID_X86_CC GOOS=android GOARCH=386 go build -ldflags="-s -w"
 try $ANDROID_X86_STRIP client
-try mv client $DIR/../src/main/assets/x86/kcptun
+try mv client $DIR/../src/main/libs/x86/libkcptun.so
 popd
 
 echo "Successfully build kcptun"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
 
     <application
             android:allowBackup="true"
-            android:extractNativeLibs="false"
             android:name=".ShadowsocksApplication"
             android:hardwareAccelerated="true"
             android:icon="@mipmap/ic_launcher"

--- a/src/main/java/com/github/shadowsocks/System.java
+++ b/src/main/java/com/github/shadowsocks/System.java
@@ -44,7 +44,6 @@ public class System {
   }
 
   public static native int exec(String cmd);
-  public static native String getABI();
   public static native int sendfd(int fd, String path);
   public static native void jniclose(int fd);
 }

--- a/src/main/jni/Android.mk
+++ b/src/main/jni/Android.mk
@@ -16,6 +16,8 @@
 LOCAL_PATH := $(call my-dir)
 ROOT_PATH := $(LOCAL_PATH)
 
+BUILD_SHARED_EXECUTABLE := $(LOCAL_PATH)/build-shared-executable.mk
+
 ########################################################
 ## libsodium
 ########################################################
@@ -358,7 +360,7 @@ LOCAL_CFLAGS := -O2 -std=gnu99 -DUSE_IPTABLES \
 	-I$(LOCAL_PATH)/libevent/include \
 	-I$(LOCAL_PATH)/libevent
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_EXECUTABLE)
 
 ########################################################
 ## pdnsd
@@ -375,7 +377,7 @@ LOCAL_CFLAGS    := -DANDROID -Wall -O2 -I$(LOCAL_PATH)/pdnsd \
 LOCAL_STATIC_LIBRARIES := libancillary
 LOCAL_LDLIBS := -llog
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_EXECUTABLE)
 
 ########################################################
 ## shadowsocks-libev local
@@ -410,7 +412,7 @@ LOCAL_STATIC_LIBRARIES := libev libmbedtls libipset libcork libudns \
 
 LOCAL_LDLIBS := -llog
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_EXECUTABLE)
 
 ########################################################
 ## shadowsocks-libev tunnel
@@ -439,7 +441,7 @@ LOCAL_STATIC_LIBRARIES := libev libmbedtls libsodium libcork libudns libancillar
 
 LOCAL_LDLIBS := -llog
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_EXECUTABLE)
 
 ########################################################
 ## system
@@ -550,7 +552,7 @@ LOCAL_LDLIBS := -ldl -llog
 
 LOCAL_SRC_FILES := $(addprefix badvpn/, $(TUN2SOCKS_SOURCES))
 
-include $(BUILD_EXECUTABLE)
+include $(BUILD_SHARED_EXECUTABLE)
 
 ########################################################
 ## mbed TLS 
@@ -574,7 +576,7 @@ include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := pcre 
+LOCAL_MODULE := pcre
 
 LOCAL_CFLAGS += -DHAVE_CONFIG_H
 

--- a/src/main/jni/build-shared-executable.mk
+++ b/src/main/jni/build-shared-executable.mk
@@ -1,0 +1,31 @@
+# Copyright (C) 2009 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# this file is included from Android.mk files to build a target-specific
+# executable program
+#
+# Modified by @Mygod, based on:
+#   https://android.googlesource.com/platform/ndk/+/f2e98f8c066aed59caf61163d4b87c2b858f9814/build/core/build-shared-library.mk
+#   https://android.googlesource.com/platform/ndk/+/f2e98f8c066aed59caf61163d4b87c2b858f9814/build/core/build-executable.mk
+LOCAL_BUILD_SCRIPT := BUILD_EXECUTABLE
+LOCAL_MAKEFILE     := $(local-makefile)
+$(call check-defined-LOCAL_MODULE,$(LOCAL_BUILD_SCRIPT))
+$(call check-LOCAL_MODULE,$(LOCAL_MAKEFILE))
+$(call check-LOCAL_MODULE_FILENAME)
+# we are building target objects
+my := TARGET_
+$(call handle-module-filename,lib,$(TARGET_SONAME_EXTENSION))
+$(call handle-module-built)
+LOCAL_MODULE_CLASS := EXECUTABLE
+include $(BUILD_SYSTEM)/build-module.mk

--- a/src/main/jni/system.cpp
+++ b/src/main/jni/system.cpp
@@ -18,25 +18,6 @@
 #define LOGW(...) do { __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__); } while(0)
 #define LOGE(...) do { __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__); } while(0)
 
-jstring Java_com_github_shadowsocks_system_getabi(JNIEnv *env, jobject thiz) {
-  AndroidCpuFamily family = android_getCpuFamily();
-  uint64_t features = android_getCpuFeatures();
-  const char *abi;
-
-  if (family == ANDROID_CPU_FAMILY_X86) {
-    abi = "x86";
-  } else if (family == ANDROID_CPU_FAMILY_MIPS) {
-    abi = "mips";
-  } else if (family == ANDROID_CPU_FAMILY_ARM) {
-    // if (features & ANDROID_CPU_ARM_FEATURE_ARMv7) {
-    abi = "armeabi-v7a";
-    // } else {
-    //   abi = "armeabi";
-    // }
-  }
-  return env->NewStringUTF(abi);
-}
-
 jint Java_com_github_shadowsocks_system_exec(JNIEnv *env, jobject thiz, jstring cmd) {
     const char *cmd_str  = env->GetStringUTFChars(cmd, 0);
 
@@ -103,9 +84,7 @@ static JNINativeMethod method_table[] = {
     { "sendfd", "(ILjava/lang/String;)I",
         (void*) Java_com_github_shadowsocks_system_sendfd },
     { "exec", "(Ljava/lang/String;)I",
-        (void*) Java_com_github_shadowsocks_system_exec },
-    { "getABI", "()Ljava/lang/String;",
-        (void*) Java_com_github_shadowsocks_system_getabi }
+        (void*) Java_com_github_shadowsocks_system_exec }
 };
 
 

--- a/src/main/scala/com/github/shadowsocks/MainActivity.scala
+++ b/src/main/scala/com/github/shadowsocks/MainActivity.scala
@@ -377,6 +377,7 @@ class MainActivity extends Activity with ServiceBoundContext with Drawer.OnDrawe
           override def handleMessage(msg: Message): Unit = if (dialog.isShowing && !isDestroyed) dialog.dismiss()
         }
         Utils.ThrowableFuture {
+          app.crashRecovery()
           app.copyAssets()
           handler.sendEmptyMessage(0)
         }

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksApplication.scala
@@ -50,8 +50,6 @@ object ShadowsocksApplication {
   var app: ShadowsocksApplication = _
 
   private final val TAG = "ShadowsocksApplication"
-  private val EXECUTABLES = Array(Executable.PDNSD, Executable.REDSOCKS, Executable.SS_TUNNEL, Executable.SS_LOCAL,
-    Executable.TUN2SOCKS, Executable.KCPTUN)
 
   // The ones in Locale doesn't have script included
   private final lazy val SIMPLIFIED_CHINESE =
@@ -180,25 +178,11 @@ class ShadowsocksApplication extends Application {
     if (holder != null) holder.refresh()
   }
 
-  private def copyAssets(path: String) {
-    val assetManager = getAssets
-    var files: Array[String] = null
-    try files = assetManager.list(path) catch {
-      case e: IOException =>
-        Log.e(TAG, e.getMessage)
-        app.track(e)
-    }
-    if (files != null) for (file <- files)
-      autoClose(assetManager.open(if (path.nonEmpty) path + '/' + file else file))(in =>
-        autoClose(new FileOutputStream(getApplicationInfo.dataDir + '/' + file))(out =>
-          IOUtils.copy(in, out)))
-  }
-
   def crashRecovery() {
     val cmd = new ArrayBuffer[String]()
 
-    for (task <- Array("ss-local", "ss-tunnel", "pdnsd", "redsocks", "tun2socks", "kcptun")) {
-      cmd.append("killall %s".formatLocal(Locale.ENGLISH, task))
+    for (task <- Executable.EXECUTABLES) {
+      cmd.append("killall lib%s.so".formatLocal(Locale.ENGLISH, task))
       cmd.append("rm -f %1$s/%2$s-nat.conf %1$s/%2$s-vpn.conf"
         .formatLocal(Locale.ENGLISH, getApplicationInfo.dataDir, task))
     }
@@ -212,10 +196,16 @@ class ShadowsocksApplication extends Application {
   }
 
   def copyAssets() {
-    crashRecovery() // ensure executables are killed before writing to them
-    copyAssets(System.getABI)
-    copyAssets("acl")
-    Shell.SH.run(EXECUTABLES.map("chmod 755 " + getApplicationInfo.dataDir + '/' + _))
+    val assetManager = getAssets
+    var files: Array[String] = null
+    try files = assetManager.list("acl") catch {
+      case e: IOException =>
+        Log.e(TAG, e.getMessage)
+        app.track(e)
+    }
+    if (files != null) for (file <- files) autoClose(assetManager.open("acl/" + file))(in =>
+      autoClose(new FileOutputStream(getApplicationInfo.dataDir + '/' + file))(out =>
+        IOUtils.copy(in, out)))
     editor.putInt(Key.currentVersionCode, BuildConfig.VERSION_CODE).apply()
   }
 

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -66,7 +66,7 @@ class ShadowsocksNatService extends BaseService {
       p.println(conf)
     })
 
-    val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-local"
+    val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so"
           , "-b" , "127.0.0.1"
           , "-t" , "600"
           , "-P", getApplicationInfo.dataDir
@@ -94,7 +94,7 @@ class ShadowsocksNatService extends BaseService {
       profile.host
     }
 
-    val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/kcptun"
+    val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libkcptun.so"
       , "-r", host + ":" + profile.kcpPort
       , "-l", "127.0.0.1:" + (profile.localPort + 90))
     try cmd ++= Utils.translateCommandline(profile.kcpcli) catch {
@@ -114,7 +114,7 @@ class ShadowsocksNatService extends BaseService {
       Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-tunnel-nat.conf"))(p => {
         p.println(conf)
       })
-      val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-tunnel"
+      val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
         , "-u"
         , "-t" , "10"
         , "-b" , "127.0.0.1"
@@ -142,7 +142,7 @@ class ShadowsocksNatService extends BaseService {
       Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-tunnel-nat.conf"))(p => {
         p.println(conf)
       })
-      val cmdBuf = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-tunnel"
+      val cmdBuf = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
         , "-t" , "10"
         , "-b" , "127.0.0.1"
         , "-l" , (profile.localPort + 63).toString
@@ -179,7 +179,7 @@ class ShadowsocksNatService extends BaseService {
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/pdnsd-nat.conf"))(p => {
        p.println(conf)
     })
-    val cmd = Array(getApplicationInfo.dataDir + "/pdnsd", "-c", getApplicationInfo.dataDir + "/pdnsd-nat.conf")
+    val cmd = Array(getApplicationInfo.nativeLibraryDir + "/libpdnsd.so", "-c", getApplicationInfo.dataDir + "/pdnsd-nat.conf")
 
     if (BuildConfig.DEBUG) Log.d(TAG, cmd.mkString(" "))
 
@@ -188,7 +188,7 @@ class ShadowsocksNatService extends BaseService {
 
   def startRedsocksDaemon() {
     val conf = ConfigUtils.REDSOCKS.formatLocal(Locale.ENGLISH, profile.localPort)
-    val cmd = Array(getApplicationInfo.dataDir + "/redsocks", "-c", getApplicationInfo.dataDir + "/redsocks-nat.conf")
+    val cmd = Array(getApplicationInfo.nativeLibraryDir + "/libredsocks.so", "-c", getApplicationInfo.dataDir + "/redsocks-nat.conf")
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/redsocks-nat.conf"))(p => {
       p.println(conf)
     })

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -182,7 +182,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       profile.host
     }
 
-    val cmd = ArrayBuffer(getApplicationInfo.dataDir + "/kcptun"
+    val cmd = ArrayBuffer(getApplicationInfo.nativeLibraryDir + "/libkcptun.so"
       , "-r", host + ":" + profile.kcpPort
       , "-l", "127.0.0.1:" + (profile.localPort + 90)
       , "--path", protectPath)
@@ -204,7 +204,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       p.println(conf)
     })
 
-    val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-local", "-V", "-U"
+    val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so", "-V", "-U"
       , "-b", "127.0.0.1"
       , "-t", "600"
       , "-P", getApplicationInfo.dataDir
@@ -231,7 +231,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       p.println(conf)
     })
 
-    val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-local", "-V"
+    val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so", "-V"
       , "-b", "127.0.0.1"
       , "-t", "600"
       , "-P", getApplicationInfo.dataDir
@@ -266,7 +266,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-tunnel-vpn.conf"))(p => {
       p.println(conf)
     })
-    val cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/ss-tunnel"
+    val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
       , "-V"
       , "-t", "10"
       , "-b", "127.0.0.1"
@@ -300,7 +300,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/pdnsd-vpn.conf"))(p => {
       p.println(conf)
     })
-    val cmd = Array(getApplicationInfo.dataDir + "/pdnsd", "-c", getApplicationInfo.dataDir + "/pdnsd-vpn.conf")
+    val cmd = Array(getApplicationInfo.nativeLibraryDir + "/libpdnsd.so", "-c", getApplicationInfo.dataDir + "/pdnsd-vpn.conf")
 
     if (BuildConfig.DEBUG) Log.d(TAG, cmd.mkString(" "))
 
@@ -358,7 +358,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
 
     val fd = conn.getFd
 
-    var cmd = ArrayBuffer[String](getApplicationInfo.dataDir + "/tun2socks",
+    var cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libtun2socks.so",
       "--netif-ipaddr", PRIVATE_VLAN.formatLocal(Locale.ENGLISH, "2"),
       "--netif-netmask", "255.255.255.0",
       "--socks-server-addr", "127.0.0.1:" + profile.localPort,

--- a/src/main/scala/com/github/shadowsocks/preferences/KcpCliPreferenceDialogFragment.scala
+++ b/src/main/scala/com/github/shadowsocks/preferences/KcpCliPreferenceDialogFragment.scala
@@ -35,7 +35,7 @@ class KcpCliPreferenceDialogFragment extends EditTextPreferenceDialogFragment {
     super.onPrepareDialogBuilder(builder)
     builder.setNeutralButton("?", ((_, _) => new AlertDialog.Builder(builder.getContext)
       .setTitle("?")
-      .setMessage(Shell.SH.run(builder.getContext.getApplicationInfo.dataDir + "/kcptun --help")
+      .setMessage(Shell.SH.run(builder.getContext.getApplicationInfo.nativeLibraryDir + "/libkcptun.so --help")
         .asScala
         .dropWhile(line => line != "GLOBAL OPTIONS:")
         .drop(1)

--- a/src/main/scala/com/github/shadowsocks/utils/Constants.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Constants.scala
@@ -27,6 +27,8 @@ object Executable {
   val SS_TUNNEL = "ss-tunnel"
   val TUN2SOCKS = "tun2socks"
   val KCPTUN = "kcptun"
+
+  val EXECUTABLES = Array(SS_LOCAL, SS_TUNNEL, PDNSD, REDSOCKS, TUN2SOCKS, KCPTUN)
 }
 
 object ConfigUtils {


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [ ] New feature
* [ ] Translation
* [x] General refinement
* Other:

### Details

Advantage:

* No more worries about inconsistencies about native libraries and extracting them (therefore no more ETXTBSY errors);
* Native libraries are counted in App section instead of Data section in storage information.

Disadvantage:

* Executable names have to be `lib*.so` otherwise Android system won't extract it.