### PR TITLE
Add an option on local address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ local.sbt
 .idea/
 out/
 .d
+*~
 
 #NDK
 src/main/obj

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ local.sbt
 .idea/
 out/
 .d
-*~
 
 #NDK
 src/main/obj

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -46,6 +46,7 @@
 <string name="tcp_fastopen_summary_unsupported">"ご利用のカーネルバージョンはサポートしておりません：%s &lt; 3.7.1"</string>
 <string name="udp_dns">"UDP転送"</string>
 <string name="udp_dns_summary">"UDPプロトコルでリモードサーバーにパケットを転送"</string>
+<string name="listen_address">"ローカルアドレス"</string>
 
 <!-- notification category -->
 <string name="forward_success">"バックグラウンドでサービスを開始しました"</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -54,6 +54,8 @@
 <string name="tcp_fastopen_summary_unsupported">"Неподдерживаемая версия ядра: %s &lt; 3.7.1"</string>
 <string name="udp_dns">"Проброс UDP"</string>
 <string name="udp_dns_summary">"Пробрасывать UDP пакеты на удалённый сервер"</string>
+<string name="listen_address">"Локальный Aдрес"</string>
+
 
 <!-- notification category -->
 <string name="forward_success">"Shadowsocks запущен."</string>

--- a/src/main/res/values-zh-rCN/strings.xml
+++ b/src/main/res/values-zh-rCN/strings.xml
@@ -47,6 +47,8 @@
 <string name="tcp_fastopen_summary_unsupported">"不支持的内核版本：%s &lt; 3.7.1"</string>
 <string name="udp_dns">"UDP 转发"</string>
 <string name="udp_dns_summary">"由远程服务器转发 UDP 协议的数据包"</string>
+<string name="listen_address">"本地地址"</string>
+
 
 <!-- notification category -->
 <string name="forward_success">"后台服务已开始运行。"</string>

--- a/src/main/res/values-zh-rTW/strings.xml
+++ b/src/main/res/values-zh-rTW/strings.xml
@@ -60,6 +60,7 @@
 <string name="vpn_error">"%s"</string>
 <string name="reboot_required">"VPN 服務啟動失敗。您或許需要重新啟動您的裝置。"</string>
 <string name="profile_invalid_input">"未找到有效的設定檔資料。"</string>
+<string name="listen_address">"本地地址"</string>
 
 <!-- alert category -->
 <string name="yes">"是"</string>

--- a/src/main/res/xml/pref_profile.xml
+++ b/src/main/res/xml/pref_profile.xml
@@ -36,6 +36,10 @@
                 android:entryValues="@array/enc_method_value"
                 android:summary="%s"
                 android:title="@string/enc_method"/>
+        <be.mygod.preference.EditTextPreference
+                android:key="listenAddress"
+                android:summary="%s"
+                android:title="@string/listen_address"/>
         <SwitchPreference
                 android:key="isAuth"
                 android:summary="@string/onetime_auth_summary"

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -55,11 +55,11 @@ class ShadowsocksNatService extends BaseService {
   def startShadowsocksDaemon() {
     val conf = if (profile.kcp) {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90, profile.localPort,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90, profile.localAddress, profile.localPort,
         profile.password, profile.method, 600)
     } else {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localAddress, profile.localPort,
         profile.password, profile.method, 600)
     }
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-local-nat.conf"))(p => {
@@ -67,7 +67,7 @@ class ShadowsocksNatService extends BaseService {
     })
 
     val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so"
-          , "-b" , "127.0.0.1"
+          , "-b" ,profile.localAddress
           , "-t" , "600"
           , "-P", getApplicationInfo.dataDir
           , "-c" , getApplicationInfo.dataDir + "/ss-local-nat.conf")
@@ -109,7 +109,7 @@ class ShadowsocksNatService extends BaseService {
   def startDNSTunnel() {
     if (profile.udpdns) {
       val conf = ConfigUtils
-        .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort + 53,
+        .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localAddress, profile.localPort + 53,
           profile.password, profile.method, 10)
       Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-tunnel-nat.conf"))(p => {
         p.println(conf)
@@ -117,7 +117,7 @@ class ShadowsocksNatService extends BaseService {
       val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
         , "-u"
         , "-t" , "10"
-        , "-b" , "127.0.0.1"
+        , "-b" , profile.localAddress
         , "-l" , (profile.localPort + 53).toString
         , "-L" , if (profile.remoteDns == null) "8.8.8.8:53" else profile.remoteDns + ":53"
         , "-P" , getApplicationInfo.dataDir
@@ -133,7 +133,7 @@ class ShadowsocksNatService extends BaseService {
       val conf = if (profile.kcp) {
         ConfigUtils
         .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90,
-          profile.localPort + 63, profile.password, profile.method, 10)
+          profile.localAddress, profile.localPort + 63, profile.password, profile.method, 10)
       } else {
         ConfigUtils
         .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort + 63,
@@ -144,7 +144,7 @@ class ShadowsocksNatService extends BaseService {
       })
       val cmdBuf = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
         , "-t" , "10"
-        , "-b" , "127.0.0.1"
+        , "-b" , profile.localAddress
         , "-l" , (profile.localPort + 63).toString
         , "-L" , if (profile.remoteDns == null) "8.8.8.8:53" else profile.remoteDns + ":53"
         , "-P", getApplicationInfo.dataDir

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -142,7 +142,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       case None => throw NameNotResolvedException()
     }
 
-    handleConnection()
+    handleConnection()///////////////////////////////////////;;;;;;;;;;;;;;;;;;;;;;;;;
     changeState(State.CONNECTED)
 
     if (profile.route != Acl.ALL && profile.route != Acl.CUSTOM_RULES)
@@ -198,14 +198,14 @@ class ShadowsocksVpnService extends VpnService with BaseService {
 
   def startShadowsocksUDPDaemon() {
     val conf = ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localAddress, profile.localPort,
         profile.password, profile.method, 600)
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-local-udp-vpn.conf"))(p => {
       p.println(conf)
     })
 
     val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so", "-V", "-U"
-      , "-b", "127.0.0.1"
+      , "-b", profile.localAddress
       , "-t", "600"
       , "-P", getApplicationInfo.dataDir
       , "-c", getApplicationInfo.dataDir + "/ss-local-udp-vpn.conf")
@@ -220,11 +220,11 @@ class ShadowsocksVpnService extends VpnService with BaseService {
   def startShadowsocksDaemon() {
     val conf = if (profile.kcp) {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90, profile.localPort,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90, profile.localAddress, profile.localPort,
         profile.password, profile.method, 600)
     } else {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localAddress, profile.localPort,
         profile.password, profile.method, 600)
     }
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-local-vpn.conf"))(p => {
@@ -232,7 +232,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
     })
 
     val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-local.so", "-V"
-      , "-b", "127.0.0.1"
+      , "-b", profile.localAddress
       , "-t", "600"
       , "-P", getApplicationInfo.dataDir
       , "-c", getApplicationInfo.dataDir + "/ss-local-vpn.conf")
@@ -256,11 +256,11 @@ class ShadowsocksVpnService extends VpnService with BaseService {
   def startDnsTunnel() {
     val conf = if (profile.kcp) {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90, profile.localPort + 63,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, "127.0.0.1", profile.localPort + 90,  profile.localAddress, profile.localPort + 63,
         profile.password, profile.method, 10)
     } else {
       ConfigUtils
-      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localPort + 63,
+      .SHADOWSOCKS.formatLocal(Locale.ENGLISH, profile.host, profile.remotePort, profile.localAddress, profile.localPort + 63,
         profile.password, profile.method, 10)
     }
     Utils.printToFile(new File(getApplicationInfo.dataDir + "/ss-tunnel-vpn.conf"))(p => {
@@ -269,7 +269,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
     val cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libss-tunnel.so"
       , "-V"
       , "-t", "10"
-      , "-b", "127.0.0.1"
+      , "-b", profile.localAddress
       , "-L" , if (profile.remoteDns == null) "8.8.8.8:53" else profile.remoteDns + ":53"
       , "-P", getApplicationInfo.dataDir
       , "-c", getApplicationInfo.dataDir + "/ss-tunnel-vpn.conf")
@@ -361,7 +361,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
     var cmd = ArrayBuffer[String](getApplicationInfo.nativeLibraryDir + "/libtun2socks.so",
       "--netif-ipaddr", PRIVATE_VLAN.formatLocal(Locale.ENGLISH, "2"),
       "--netif-netmask", "255.255.255.0",
-      "--socks-server-addr", "127.0.0.1:" + profile.localPort,
+      "--socks-server-addr", profile.localAddress + ":" + profile.localPort,
       "--tunfd", fd.toString,
       "--tunmtu", VPN_MTU.toString,
       "--sock-path", getApplicationInfo.dataDir + "/sock_path",

--- a/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -142,7 +142,7 @@ class ShadowsocksVpnService extends VpnService with BaseService {
       case None => throw NameNotResolvedException()
     }
 
-    handleConnection()///////////////////////////////////////;;;;;;;;;;;;;;;;;;;;;;;;;
+    handleConnection()
     changeState(State.CONNECTED)
 
     if (profile.route != Acl.ALL && profile.route != Acl.CUSTOM_RULES)

--- a/src/main/scala/com/github/shadowsocks/database/DBHelper.scala
+++ b/src/main/scala/com/github/shadowsocks/database/DBHelper.scala
@@ -88,9 +88,9 @@ class DBHelper(val context: Context)
           profileDao.executeRawNoArgs("ALTER TABLE `profile` RENAME TO `tmp`;")
           TableUtils.createTable(connectionSource, classOf[Profile])
           profileDao.executeRawNoArgs(
-            "INSERT INTO `profile`(id, name, host, localPort, remotePort, password, method, route, proxyApps, bypass," +
+            "INSERT INTO `profile`(id, name, host, localAddress, localPort, remotePort, password, method, route, proxyApps, bypass," +
               " udpdns, auth, ipv6, individual) " +
-            "SELECT id, name, host, localPort, remotePort, password, method, route, 1 - global, bypass, udpdns, auth," +
+            "SELECT id, name, host, localAddress, localPort, remotePort, password, method, route, 1 - global, bypass, udpdns, auth," +
             " ipv6, individual FROM `tmp`;")
           profileDao.executeRawNoArgs("DROP TABLE `tmp`;")
           profileDao.executeRawNoArgs("COMMIT;")

--- a/src/main/scala/com/github/shadowsocks/database/Profile.scala
+++ b/src/main/scala/com/github/shadowsocks/database/Profile.scala
@@ -40,6 +40,9 @@ class Profile {
   @DatabaseField
   var host: String = "198.199.101.152"
 
+  @DatabaseField
+  var localAddress: String = "127.0.0.1"
+
   // hopefully hashCode = mHandle doesn't change, currently this is true from KitKat to Nougat
   @DatabaseField
   var localPort: Int = 1080 + Binder.getCallingUserHandle.hashCode
@@ -111,6 +114,7 @@ class Profile {
   def serialize(editor: SharedPreferences.Editor): SharedPreferences.Editor = editor
     .putString(Key.name, name)
     .putString(Key.host, host)
+    .putString(Key.localAddress, localAddress)
     .putInt(Key.localPort, localPort)
     .putInt(Key.remotePort, remotePort)
     .putString(Key.password, password)
@@ -131,6 +135,7 @@ class Profile {
     // It's assumed that default values are never used, so 0/false/null is always used even if that isn't the case
     name = pref.getString(Key.name, null)
     host = pref.getString(Key.host, null)
+    localAddress = pref.getString(Key.localAddress, null)
     localPort = pref.getInt(Key.localPort, 0)
     remotePort = pref.getInt(Key.remotePort, 0)
     password = pref.getString(Key.password, null)

--- a/src/main/scala/com/github/shadowsocks/utils/Constants.scala
+++ b/src/main/scala/com/github/shadowsocks/utils/Constants.scala
@@ -32,7 +32,7 @@ object Executable {
 }
 
 object ConfigUtils {
-  val SHADOWSOCKS = "{\"server\": \"%s\", \"server_port\": %d, \"local_port\": %d, \"password\": \"%s\", \"method\":\"%s\", \"timeout\": %d}"
+  val SHADOWSOCKS = "{\"server\": \"%s\", \"server_port\": %d, \"local_address\": \"%s\", \"local_port\": %d, \"password\": \"%s\", \"method\":\"%s\", \"timeout\": %d}"
   val REDSOCKS = "base {\n" +
     " log_debug = off;\n" +
     " log_info = off;\n" +
@@ -150,8 +150,10 @@ object Key {
   val password = "sitekey"
   val method = "encMethod"
   val remotePort = "remotePortNum"
+  var localAddress = "listenAddress"
   val localPort = "localPortNum"
   val remoteDns = "remoteDns"
+
 
   val kcp = "kcp"
   val kcpPort = "kcpPort"


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [x] New feature
* [ ] Translation
* [ ] General refinement
* Other:

### Details

Please provide more details about changes if necessary.

Hi, this is a little tweak `adding an option on local_address`. So the ss-local/ss-tunnel will be able to expose its service to somewhere, mainly used in lan.

As you can see the commit is simple enough so no more explanations.

This can be useful because many linux distributions lacks built-package of ss-libev ,especially when python ss could be extremley slow and unstable with massive connections and without acl, that will be even hard to pull the needed source to build ss-libev. Like the problem of chicken or egg.
That is the situation I am up to these days. So I figured this out to solve it.