### PR TITLE
MaxPermSize was removed in JDK 1.8

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
--XX:MaxPermSize=512m
 -Xms1g
 -Xmx3g
 -Xss2m


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [ ] New feature
* [ ] Translation
* [x] General refinement
* Other:

### Details

The `MaxPermSize` param was removed in JDK 1.8
