### PR TITLE
Add secondary remote dns support.

### DIFF
--- a/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -223,11 +223,13 @@ class ShadowsocksVpnService extends VpnService with BaseService {
         val subnet = Subnet.fromString(cidr)
         builder.addRoute(subnet.address.getHostAddress, subnet.prefixSize)
       })
-      val addr = InetAddress.getByName(profile.remoteDns.trim)
-      if (addr.isInstanceOf[Inet6Address])
-        builder.addRoute(addr, 128)
-      else if (addr.isInstanceOf[InetAddress])
-        builder.addRoute(addr, 32)
+      profile.remoteDns.trim.split(",").foreach(remoteDns => {
+        val addr = InetAddress.getByName(remoteDns.trim)
+        if (addr.isInstanceOf[Inet6Address])
+          builder.addRoute(addr, 128)
+        else if (addr.isInstanceOf[InetAddress])
+          builder.addRoute(addr, 32)
+      })
     }
 
     conn = builder.establish()


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [x] New feature
* [ ] Translation
* [ ] General refinement
* Other:

### Details

Add secondary remote dns support:
192.168.1.1,192.168.1.2
In certain scenario, one may use own custom dns server.
Well, hard code secondary dns 208.67.222.222 may be annoying.
This provides a way to change it.

BTW:
remove duplicated "import java.net.InetAddress" is for "强迫症".