### PR TITLE
Add multiple remote dns support. Remove alternative dns in global mode.

### DIFF
--- a/mobile/src/main/scala/com/github/shadowsocks/BaseService.scala
+++ b/mobile/src/main/scala/com/github/shadowsocks/BaseService.scala
@@ -21,7 +21,6 @@
 package com.github.shadowsocks
 
 import java.io.{File, IOException}
-import java.net.InetAddress
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.{Timer, TimerTask}
@@ -365,18 +364,26 @@ trait BaseService extends Service {
           makeDns("Primary-1", "119.29.29.29", edns = false),
           makeDns("Primary-2", "114.114.114.114", edns = false)
         )))
-        .put("AlternativeDNS", new JSONArray().put(makeDns("Alternative",
-          buildRemoteDns(profile.remoteDns.trim))))
+        .put("AlternativeDNS", new JSONArray(
+          for (remoteDns <- profile.remoteDns.split(","))
+            yield makeDns(remoteDns.trim, buildRemoteDns(remoteDns.trim)
+        )))
         .put("IPNetworkFile", "china_ip_list.txt")
         .put("DomainFile", "gfwlist.txt")
       case Acl.CHINALIST => config
         .put("PrimaryDNS", new JSONArray().put(makeDns("Primary", "119.29.29.29")))
-        .put("AlternativeDNS", new JSONArray().put(makeDns("Alternative",
-          buildRemoteDns(profile.remoteDns.trim))))
+        .put("AlternativeDNS", new JSONArray(
+          for (remoteDns <- profile.remoteDns.split(","))
+            yield makeDns(remoteDns.trim, buildRemoteDns(remoteDns.trim)
+        )))
       case _ => config
-        .put("PrimaryDNS", new JSONArray().put(makeDns("Primary",
-          buildRemoteDns(profile.remoteDns.trim))))
-        .put("AlternativeDNS", new JSONArray().put(makeDns("Alternative", "208.67.222.222")))
+        .put("PrimaryDNS", new JSONArray(
+          for (remoteDns <- profile.remoteDns.split(","))
+            yield makeDns(remoteDns.trim, buildRemoteDns(remoteDns.trim)
+        )))
+        // no need to setup AlternativeDNS in Acl.ALL/BYPASS_LAN mode
+        // .put("AlternativeDNS", new JSONArray().put(makeDns("Alternative", "208.67.222.222")))
+        .put("OnlyPrimaryDNS", true)
     }
     IOUtils.writeString(new File(getFilesDir, file), config.toString)
     file

--- a/mobile/src/main/scala/com/github/shadowsocks/BaseService.scala
+++ b/mobile/src/main/scala/com/github/shadowsocks/BaseService.scala
@@ -382,7 +382,6 @@ trait BaseService extends Service {
             yield makeDns(remoteDns.trim, buildRemoteDns(remoteDns.trim)
         )))
         // no need to setup AlternativeDNS in Acl.ALL/BYPASS_LAN mode
-        // .put("AlternativeDNS", new JSONArray().put(makeDns("Alternative", "208.67.222.222")))
         .put("OnlyPrimaryDNS", true)
     }
     IOUtils.writeString(new File(getFilesDir, file), config.toString)

--- a/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
+++ b/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksNatService.scala
@@ -74,7 +74,7 @@ class ShadowsocksNatService extends BaseService {
       "-t", "10",
       "-b", "127.0.0.1",
       "-l", (profile.localPort + 63).toString,
-      "-L", profile.remoteDns.trim + ":53",
+      "-L", profile.remoteDns.split(",")(0).trim + ":53",
       "-c", buildShadowsocksConfig("ss-tunnel-nat.conf"))
 
     if (profile.udpdns) cmd.append("-u")

--- a/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
+++ b/mobile/src/main/scala/com/github/shadowsocks/ShadowsocksVpnService.scala
@@ -223,11 +223,13 @@ class ShadowsocksVpnService extends VpnService with BaseService {
         val subnet = Subnet.fromString(cidr)
         builder.addRoute(subnet.address.getHostAddress, subnet.prefixSize)
       })
-      val addr = InetAddress.getByName(profile.remoteDns.trim)
-      if (addr.isInstanceOf[Inet6Address])
-        builder.addRoute(addr, 128)
-      else if (addr.isInstanceOf[InetAddress])
-        builder.addRoute(addr, 32)
+      profile.remoteDns.split(",").foreach(remoteDns => {
+        val addr = InetAddress.getByName(remoteDns.trim)
+        if (addr.isInstanceOf[Inet6Address])
+          builder.addRoute(addr, 128)
+        else if (addr.isInstanceOf[InetAddress])
+          builder.addRoute(addr, 32)
+      })
     }
 
     conn = builder.establish()


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [x] Bugfix
* [x] New feature
* [ ] Translation
* [ ] General refinement
* Other:

### Details

Add secondary remote dns support:
192.168.1.1,192.168.1.2
Overture config example:
`{"BindAddress":":1133","RedirectIPv6Record":true,"DomainBase64Decode":true,"HostsFile":"hosts","MinimumTTL":3600,"CacheSize":4096,"PrimaryDNS":[{"Name":"Primary-1","Address":"119.29.29.29:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"udp"},{"Name":"Primary-2","Address":"114.114.114.114:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"udp"}],"AlternativeDNS":[{"Name":"8.8.8.8","Address":"8.8.8.8:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"tcp","Socks5Address":"127.0.0.1:1080"},{"Name":"8.8.4.4","Address":"8.8.4.4:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"tcp","Socks5Address":"127.0.0.1:1080"}],"IPNetworkFile":"china_ip_list.txt","DomainFile":"gfwlist.txt"}`

Remove alternative dns in global mode, because the primary dns should be clean dns, no need to query from OpenDNS again.
`{"BindAddress":":1133","RedirectIPv6Record":true,"DomainBase64Decode":true,"HostsFile":"hosts","MinimumTTL":3600,"CacheSize":4096,"PrimaryDNS":[{"Name":"8.8.8.8","Address":"8.8.8.8:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"tcp","Socks5Address":"127.0.0.1:1080"},{"Name":"8.8.4.4","Address":"8.8.4.4:53","Timeout":6,"EDNSClientSubnet":{"Policy":"disable"},"Protocol":"tcp","Socks5Address":"127.0.0.1:1080"}],"OnlyPrimaryDNS":true}`