### PR TITLE
Limit abi for consistency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val commonSettings = Seq(
   javacOptions ++= "-source" :: "1.7" :: "-target" :: "1.7" :: Nil,
   scalacOptions ++= "-target:jvm-1.7" :: "-Xexperimental" :: Nil,
   ndkArgs := "-j" :: java.lang.Runtime.getRuntime.availableProcessors.toString :: Nil,
+  ndkAbiFilter := Seq("armeabi-v7a", "arm64-v8a", "x86"),
 
   proguardVersion := "5.3.3",
   proguardCache := Seq(),


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [ ] New feature
* [ ] Translation
* [x] General refinement
* Other:

### Details

Keeps overall abi consistent with `mobile/src/main/jni/Application.mk` and `mobile/src/overture/make.bash`

If any future library dependencies come with extra abis, say `x64/foo.so`, the x64 abi will be packaged into the final apk.

Therefore, the `lib` folder of the apk will look like:
```
armeabi-v7a/foo.so
armeabi-v7a/others.so
arm64-v8a/foo.so
arm64-v8a/others.so
x86/foo.so
x86/others.so
x64/foo.so
```

If the apk is installed into a x64 android phone, `x64/others.so` cannot be found and the program may crash.

Adding `ndkAbiFilter` ensures that only defined abis are included into the apk.
