### PR TITLE
Fix Windows build script of overture

### DIFF
--- a/core/src/overture/make.bat
+++ b/core/src/overture/make.bat
@@ -46,7 +46,7 @@ IF NOT EXIST %ANDROID_X86_CC% (
         --api %MIN_API% --install-dir %ANDROID_X86_TOOLCHAIN%
 )
 
-IF NOT EXIST %DIR%\go\bin\go (
+IF NOT EXIST %DIR%\go\bin\go.exe (
     ECHO "Build the custom go"
 
     PUSHD %DIR%\go\src


### PR DESCRIPTION
### Type of changes

* [x] Bugfix
* [ ] New feature
* [ ] Translation
* [ ] General refinement
* Other:

### Details
make.bat not detect Windows go binary due to missing '.exe' of filename
when the script convert from bash to bat.