### PR TITLE
adjust timeout for ss-local from 600 to 60

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -240,7 +240,7 @@ object BaseService {
                     "-u",
                     "-b", "127.0.0.1",
                     "-l", DataStore.portProxy.toString(),
-                    "-t", "600",
+                    "-t", "60",
                     "-c", data.buildShadowsocksConfig().absolutePath))
 
             val acl = data.aclFile


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [ ] New feature
* [ ] Translation
* [ ] General refinement
* Other: Adjust ss-local's timeout from 600 to 60.

### Details

The real timeout for shadowsocks is the minimum of ss-server's timeout and ss-local's timeout. In shadowsocks-android, the origin timeout for ss-local (600) seems to long, so I changed this argument from 600 to 60.

And I think, the best way of handling timeout argument is to let it be decided by the user, not hard-coded in the source file.
