### PR TITLE
Get rid of -V flag

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/JniHelper.java
+++ b/core/src/main/java/com/github/shadowsocks/JniHelper.java
@@ -70,7 +70,6 @@ public class JniHelper {
     private static native Integer getExitValue(Process process);
     private static native Object getExitValueMutex(Process process);
     public static native int sendFd(int fd, @NonNull String path);
-    public static native void close(int fd);
     @Nullable
     public static native byte[] parseNumericAddress(@NonNull String str);
 }

--- a/core/src/main/jni/jni-helper.cpp
+++ b/core/src/main/jni/jni-helper.cpp
@@ -68,10 +68,6 @@ JNIEXPORT jobject JNICALL
     return env->GetObjectField(process, ProcessImpl_exitValueMutex);
 }
 
-JNIEXPORT void JNICALL Java_com_github_shadowsocks_JniHelper_close(JNIEnv *env, jobject thiz, jint fd) {
-    close(fd);
-}
-
 JNIEXPORT jint JNICALL
         Java_com_github_shadowsocks_JniHelper_sendFd(JNIEnv *env, jobject thiz, jint tun_fd, jstring path) {
     int fd;

--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -64,8 +64,6 @@ import com.mikepenz.materialdrawer.model.PrimaryDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.net.InetSocketAddress
-import java.net.Proxy
 import java.net.URL
 import java.util.*
 
@@ -166,10 +164,7 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, Drawe
             Acl.CHINALIST -> "www.qualcomm.cn"
             else -> "www.google.com"
         }, "/generate_204")
-        val conn = (if (BaseService.usingVpnMode) url.openConnection() else
-            url.openConnection(Proxy(Proxy.Type.SOCKS,
-                    InetSocketAddress("127.0.0.1", DataStore.portProxy))))
-                as HttpURLConnection
+        val conn = (url.openConnection(DataStore.proxy)) as HttpURLConnection
         conn.setRequestProperty("Connection", "close")
         conn.instanceFollowRedirects = false
         conn.useCaches = false

--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -164,7 +164,7 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, Drawe
             Acl.CHINALIST -> "www.qualcomm.cn"
             else -> "www.google.com"
         }, "/generate_204")
-        val conn = (url.openConnection(DataStore.proxy)) as HttpURLConnection
+        val conn = url.openConnection(DataStore.proxy) as HttpURLConnection
         conn.setRequestProperty("Connection", "close")
         conn.instanceFollowRedirects = false
         conn.useCaches = false

--- a/mobile/src/main/java/com/github/shadowsocks/acl/AclSyncJob.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/acl/AclSyncJob.kt
@@ -24,6 +24,7 @@ import android.util.Log
 import com.evernote.android.job.Job
 import com.evernote.android.job.JobCreator
 import com.evernote.android.job.JobRequest
+import com.github.shadowsocks.preference.DataStore
 import java.io.IOException
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -54,8 +55,8 @@ class AclSyncJob(private val route: String) : Job() {
     }
 
     override fun onRunJob(params: Params): Result = try {
-        val acl = URL("https://shadowsocks.org/acl/android/v1/$route.acl").openStream().bufferedReader()
-                .use { it.readText() }
+        val acl = URL("https://shadowsocks.org/acl/android/v1/$route.acl").openConnection(DataStore.proxy)
+                .getInputStream().bufferedReader().use { it.readText() }
         Acl.getFile(route).printWriter().use { it.write(acl) }
         Result.SUCCESS
     } catch (e: IOException) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -194,7 +194,7 @@ object BaseService {
                 val pluginCmd = arrayListOf(pluginPath)
                 if (TcpFastOpen.sendEnabled) pluginCmd.add("--fast-open")
                 config
-                        .put("plugin", Commandline.toString(service.buildAdditionalArguments(pluginCmd)))
+                        .put("plugin", pluginCmd)
                         .put("plugin_opts", plugin.toString())
             }
             // sensitive Shadowsocks config is stored in
@@ -251,18 +251,16 @@ object BaseService {
             }
         }
 
-        fun buildAdditionalArguments(cmd: ArrayList<String>): ArrayList<String> = cmd
-
         fun startNativeProcesses() {
             val data = data
             val profile = data.profile!!
-            val cmd = buildAdditionalArguments(arrayListOf(
+            val cmd = arrayListOf(
                     File((this as Context).applicationInfo.nativeLibraryDir, Executable.SS_LOCAL).absolutePath,
                     "-u",
                     "-b", "127.0.0.1",
                     "-l", DataStore.portProxy.toString(),
                     "-t", "600",
-                    "-c", data.buildShadowsocksConfig().absolutePath))
+                    "-c", data.buildShadowsocksConfig().absolutePath)
 
             val acl = data.aclFile
             if (acl != null) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -191,11 +191,16 @@ object BaseService {
                     .put("method", profile.method)
             val pluginPath = pluginPath
             if (pluginPath != null) {
-                val pluginCmd = arrayListOf(pluginPath)
-                if (TcpFastOpen.sendEnabled) pluginCmd.add("--fast-open")
+                val pluginCmd = pluginPath
+                val pluginOpts = if (TcpFastOpen.sendEnabled) {
+                    plugin.toString() + ";fast-open"
+                }
+                else {
+                    plugin.toString()
+                }
                 config
                         .put("plugin", pluginCmd)
-                        .put("plugin_opts", plugin.toString())
+                        .put("plugin_opts", pluginOpts)
             }
             // sensitive Shadowsocks config is stored in
             val file = File(if (UserManagerCompat.isUserUnlocked(app)) app.filesDir else @TargetApi(24) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -191,16 +191,10 @@ object BaseService {
                     .put("method", profile.method)
             val pluginPath = pluginPath
             if (pluginPath != null) {
-                val pluginCmd = pluginPath
-                val pluginOpts = if (TcpFastOpen.sendEnabled) {
-                    plugin.toString() + ";fast-open"
-                }
-                else {
-                    plugin.toString()
-                }
+                if (TcpFastOpen.sendEnabled) plugin["fast-open"] = null
                 config
-                        .put("plugin", pluginCmd)
-                        .put("plugin_opts", pluginOpts)
+                        .put("plugin", pluginPath)
+                        .put("plugin_opts", plugin.toString())
             }
             // sensitive Shadowsocks config is stored in
             val file = File(if (UserManagerCompat.isUserUnlocked(app)) app.filesDir else @TargetApi(24) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
@@ -96,10 +96,10 @@ object LocalDnsService {
                 return file
             }
 
-            if (!profile.udpdns) overtureProcess = GuardedProcess(buildAdditionalArguments(arrayListOf(
+            if (!profile.udpdns) overtureProcess = GuardedProcess(arrayListOf(
                     File(app.applicationInfo.nativeLibraryDir, Executable.OVERTURE).absolutePath,
                     "-c", buildOvertureConfig("overture.conf")
-            ))).start()
+            )).start()
         }
 
         override fun killProcesses() {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -159,6 +159,8 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
                         }
                     }
             if (profile.bypass) builder.addDisallowedApplication(me)
+        } else {
+            builder.addDisallowedApplication(packageName)
         }
 
         when (profile.route) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -26,7 +26,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.*
-import android.os.Build
 import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import android.support.v4.os.BuildCompat
@@ -41,9 +40,7 @@ import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.Subnet
 import com.github.shadowsocks.utils.parseNumericAddress
 import java.io.File
-import java.io.FileDescriptor
 import java.io.IOException
-import java.lang.reflect.Method
 import java.util.*
 import android.net.VpnService as BaseVpnService
 
@@ -52,8 +49,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
         private const val VPN_MTU = 1500
         private const val PRIVATE_VLAN = "26.26.26.%s"
         private const val PRIVATE_VLAN6 = "fdfe:dcba:9876::%s"
-
-        private val getInt: Method = FileDescriptor::class.java.getDeclaredMethod("getInt$")
 
         /**
          * Unfortunately registerDefaultNetworkCallback is going to return VPN interface since Android P DP1:
@@ -71,39 +66,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
                 .build()
     }
 
-    private inner class ProtectWorker : LocalSocketListener("ShadowsocksVpnThread") {
-        override val socketFile: File = File(app.deviceContext.filesDir, "protect_path")
-
-        override fun accept(socket: LocalSocket) {
-            var success = false
-            try {
-                socket.inputStream.read()
-                val fd = socket.ancillaryFileDescriptors!!.single()!!
-                val fdInt = getInt.invoke(fd) as Int
-                try {
-                    val network = underlyingNetwork
-                    success = if (network != null && Build.VERSION.SDK_INT >= 23) {
-                        network.bindSocket(fd)
-                        true
-                    } else protect(fdInt)
-                } catch (e: Exception) {
-                    Log.e(tag, "Error when protect socket", e)
-                    app.track(e)
-                } finally {
-                    JniHelper.close(fdInt) // Trick to close file decriptor
-                }
-            } catch (e: Exception) {
-                Log.e(tag, "Error when receiving ancillary fd", e)
-                app.track(e)
-            }
-            try {
-                socket.outputStream.write(if (success) 0 else 1)
-            } catch (e: IOException) {
-                Log.e(tag, "Error when returning result in protect", e)
-                app.track(e)
-            }
-        }
-    }
     class NullConnectionException : NullPointerException()
 
     init {
@@ -115,27 +77,20 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
             ServiceNotification(this, profileName, "service-vpn")
 
     private var conn: ParcelFileDescriptor? = null
-    private var worker: ProtectWorker? = null
     private var tun2socksProcess: GuardedProcess? = null
-    private var underlyingNetwork: Network? = null
-        @TargetApi(28)
-        set(value) {
-            setUnderlyingNetworks(if (value == null) null else arrayOf(value))
-            field = value
-        }
 
     private val connectivity by lazy { getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager }
     @TargetApi(28)
     private val defaultNetworkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            underlyingNetwork = network
+            setUnderlyingNetworks(arrayOf(network))
         }
         override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities?) {
             // it's a good idea to refresh capabilities
-            underlyingNetwork = network
+            setUnderlyingNetworks(arrayOf(network))
         }
         override fun onLost(network: Network) {
-            underlyingNetwork = null
+            setUnderlyingNetworks(null)
         }
     }
     private var listeningForDefaultNetwork = false
@@ -152,8 +107,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
             connectivity.unregisterNetworkCallback(defaultNetworkCallback)
             listeningForDefaultNetwork = false
         }
-        worker?.stopThread()
-        worker = null
         super.killProcesses()
         tun2socksProcess?.destroy()
         tun2socksProcess = null
@@ -172,19 +125,10 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
     }
 
     override fun startNativeProcesses() {
-        val worker = ProtectWorker()
-        worker.start()
-        this.worker = worker
-
         super.startNativeProcesses()
 
         val fd = startVpn()
         if (!sendFd(fd)) throw IOException("sendFd failed")
-    }
-
-    override fun buildAdditionalArguments(cmd: ArrayList<String>): ArrayList<String> {
-        cmd += "-V"
-        return cmd
     }
 
     private fun startVpn(): Int {
@@ -214,7 +158,7 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
                             Log.e(tag, "Invalid package name", ex)
                         }
                     }
-            if (!profile.bypass) builder.addAllowedApplication(me)
+            if (profile.bypass) builder.addDisallowedApplication(me)
         }
 
         when (profile.route) {

--- a/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -146,8 +146,8 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
             builder.addRoute("::", 0)
         }
 
+        val me = packageName
         if (profile.proxyApps) {
-            val me = packageName
             profile.individual.split('\n')
                     .filter { it != me }
                     .forEach {
@@ -160,7 +160,7 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
                     }
             if (profile.bypass) builder.addDisallowedApplication(me)
         } else {
-            builder.addDisallowedApplication(packageName)
+            builder.addDisallowedApplication(me)
         }
 
         when (profile.route) {

--- a/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -27,6 +27,8 @@ import com.github.shadowsocks.database.PublicDatabase
 import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.Key
 import com.github.shadowsocks.utils.parsePort
+import java.net.InetSocketAddress
+import java.net.Proxy
 
 object DataStore {
     val publicStore = OrmLitePreferenceDataStore(PublicDatabase.kvPairDao)
@@ -63,6 +65,8 @@ object DataStore {
     var portTransproxy: Int
         get() = getLocalPort(Key.portTransproxy, 8200)
         set(value) = publicStore.putString(Key.portTransproxy, value.toString())
+
+    val proxy get() = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", portProxy))
 
     fun initGlobal() {
         // temporary workaround for support lib bug


### PR DESCRIPTION
:construction: **ONLY INTENDED FOR DEBUGGING PURPOSES DO NOT MERGE** :construction:

By disallowing this app itself, every socket created by this app will go through default network automatically. However, since it's called *disallowing*, Android system won't let us bind to VPN tunnel. Therefore we will have to resort to using proxies to connect with Shadowsocks.

Pros:
1. No more ancillary fd passing;
2. ~No more go lib patching;~
3. Easier plugin development.

Cons:
1. ~Ads might not work if Google is blocked; (unless it goes through Google Service Framework)~
2. Connection test will have to test through proxy instead of the better testing method through VPN tunnel;
3. All sockets will use default network and therefore we are no longer using underlying network;
4. ~Only works on Android 5.0+.~