### PR TITLE
Manage all processes with GuardedProcessPool

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -76,7 +76,7 @@ object BaseService {
         @Volatile var state = STOPPED
         @Volatile var plugin = PluginOptions()
         @Volatile var pluginPath: String? = null
-        var sslocalProcess: GuardedProcess? = null
+        val processes = GuardedProcessPool()
 
         var timer: Timer? = null
         var trafficMonitorThread: TrafficMonitorThread? = null
@@ -274,7 +274,7 @@ object BaseService {
 
             if (TcpFastOpen.sendEnabled) cmd += "--fast-open"
 
-            data.sslocalProcess = GuardedProcess(cmd).start()
+            data.processes.start(cmd)
         }
 
         fun createNotification(profileName: String): ServiceNotification
@@ -285,11 +285,7 @@ object BaseService {
             else startService(Intent(this, javaClass))
         }
 
-        fun killProcesses() {
-            val data = data
-            data.sslocalProcess?.destroy()
-            data.sslocalProcess = null
-        }
+        fun killProcesses() = data.processes.killAll()
 
         fun stopRunner(stopService: Boolean, msg: String? = null) {
             // channge the state

--- a/mobile/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
@@ -28,19 +28,9 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.net.Inet6Address
-import java.util.*
 
-/**
- * This object also uses WeakMap to simulate the effects of multi-inheritance, but more lightweight.
- */
 object LocalDnsService {
     interface Interface : BaseService.Interface {
-        var overtureProcess: GuardedProcess?
-            get() = overtureProcesses[this]
-            set(value) {
-                if (value == null) overtureProcesses.remove(this) else overtureProcesses[this] = value
-            }
-
         override fun startNativeProcesses() {
             super.startNativeProcesses()
             val data = data
@@ -96,18 +86,10 @@ object LocalDnsService {
                 return file
             }
 
-            if (!profile.udpdns) overtureProcess = GuardedProcess(buildAdditionalArguments(arrayListOf(
+            if (!profile.udpdns) data.processes.start(buildAdditionalArguments(arrayListOf(
                     File(app.applicationInfo.nativeLibraryDir, Executable.OVERTURE).absolutePath,
                     "-c", buildOvertureConfig("overture.conf")
-            ))).start()
-        }
-
-        override fun killProcesses() {
-            super.killProcesses()
-            overtureProcess?.destroy()
-            overtureProcess = null
+            )))
         }
     }
-
-    private val overtureProcesses = WeakHashMap<Interface, GuardedProcess>()
 }

--- a/mobile/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
@@ -40,18 +40,14 @@ class TransproxyService : Service(), LocalDnsService.Interface {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
             super<LocalDnsService.Interface>.onStartCommand(intent, flags, startId)
 
-    private var sstunnelProcess: GuardedProcess? = null
-    private var redsocksProcess: GuardedProcess? = null
-
     private fun startDNSTunnel() {
-        val cmd = arrayListOf(File(applicationInfo.nativeLibraryDir, Executable.SS_TUNNEL).absolutePath,
+        data.processes.start(listOf(File(applicationInfo.nativeLibraryDir, Executable.SS_TUNNEL).absolutePath,
                 "-t", "10",
                 "-b", "127.0.0.1",
                 "-u",
                 "-l", DataStore.portLocalDns.toString(),            // ss-tunnel listens on the same port as overture
                 "-L", data.profile!!.remoteDns.split(",").first().trim() + ":53",
-                "-c", data.shadowsocksConfigFile!!.absolutePath)    // config is already built by BaseService.Interface
-        sstunnelProcess = GuardedProcess(cmd).start()
+                "-c", data.shadowsocksConfigFile!!.absolutePath))   // config is already built by BaseService.Interface
     }
 
     private fun startRedsocksDaemon() {
@@ -70,23 +66,13 @@ redsocks {
  type = socks5;
 }
 """)
-        redsocksProcess = GuardedProcess(arrayListOf(
-                File(applicationInfo.nativeLibraryDir, Executable.REDSOCKS).absolutePath,
-                "-c", "redsocks.conf")
-        ).start()
+        data.processes.start(listOf(
+                File(applicationInfo.nativeLibraryDir, Executable.REDSOCKS).absolutePath, "-c", "redsocks.conf"))
     }
 
     override fun startNativeProcesses() {
         startRedsocksDaemon()
         super.startNativeProcesses()
         if (data.profile!!.udpdns) startDNSTunnel()
-    }
-
-    override fun killProcesses() {
-        super.killProcesses()
-        sstunnelProcess?.destroy()
-        sstunnelProcess = null
-        redsocksProcess?.destroy()
-        redsocksProcess = null
     }
 }

--- a/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -116,7 +116,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
 
     private var conn: ParcelFileDescriptor? = null
     private var worker: ProtectWorker? = null
-    private var tun2socksProcess: GuardedProcess? = null
     private var underlyingNetwork: Network? = null
         @TargetApi(28)
         set(value) {
@@ -155,8 +154,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
         worker?.stopThread()
         worker = null
         super.killProcesses()
-        tun2socksProcess?.destroy()
-        tun2socksProcess = null
         conn?.close()
         conn = null
     }
@@ -256,7 +253,7 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
             cmd += "--dnsgw"
             cmd += "127.0.0.1:${DataStore.portLocalDns}"
         }
-        tun2socksProcess = GuardedProcess(cmd).start { sendFd(fd) }
+        data.processes.start(cmd) { sendFd(fd) }
         return fd
     }
 


### PR DESCRIPTION
### Type of changes

* [x] General refinement

### Details

This way we can destroy the processes and wait for them to exit in parallel, and ensure the process is destroyed so that we won't encounter strange port being used issue at the same time.

This addresses #1740 but probably doesn't fix it.