### PR TITLE
make connection test url configurable

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -166,9 +166,7 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, Drawe
      */
     private fun testConnection(id: Int) {
         val (success, result) = try {
-            val urlString = when (app.currentProfile!!.route) {
-                Acl.CHINALIST -> DataStore.testUrlChinaList
-                else -> DataStore.testUrl}
+            val urlString = DataStore.testUrl
             val url = URL(urlString)
             if (url.protocol != "https")
                 throw MalformedURLException(getString(R.string.connection_test_url_non_https, urlString))

--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -41,7 +41,9 @@ import android.support.v7.content.res.AppCompatResources
 import android.support.v7.preference.PreferenceDataStore
 import android.text.format.Formatter
 import android.util.Log
+import android.util.Patterns
 import android.view.View
+import android.webkit.URLUtil
 import android.widget.TextView
 import com.github.shadowsocks.App.Companion.app
 import com.github.shadowsocks.acl.Acl
@@ -65,6 +67,7 @@ import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.InetSocketAddress
+import java.net.MalformedURLException
 import java.net.Proxy
 import java.net.URL
 import java.util.*
@@ -162,28 +165,36 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, Drawe
      * Based on: https://android.googlesource.com/platform/frameworks/base/+/97bfd27/services/core/java/com/android/server/connectivity/NetworkMonitor.java#879
      */
     private fun testConnection(id: Int) {
-        val url = URL("https", when (app.currentProfile!!.route) {
-            Acl.CHINALIST -> "www.qualcomm.cn"
-            else -> "www.google.com"
-        }, "/generate_204")
-        val conn = (if (BaseService.usingVpnMode) url.openConnection() else
-            url.openConnection(Proxy(Proxy.Type.SOCKS,
-                    InetSocketAddress("127.0.0.1", DataStore.portProxy))))
-                as HttpURLConnection
-        conn.setRequestProperty("Connection", "close")
-        conn.instanceFollowRedirects = false
-        conn.useCaches = false
         val (success, result) = try {
-            val start = SystemClock.elapsedRealtime()
-            val code = conn.responseCode
-            val elapsed = SystemClock.elapsedRealtime() - start
-            if (code == 204 || code == 200 && conn.responseLength == 0L)
-                Pair(true, getString(R.string.connection_test_available, elapsed))
-            else throw IOException(getString(R.string.connection_test_error_status_code, code))
-        } catch (e: IOException) {
-            Pair(false, getString(R.string.connection_test_error, e.message))
-        } finally {
-            conn.disconnect()
+            val urlString = when (app.currentProfile!!.route) {
+                Acl.CHINALIST -> DataStore.testUrlChinaList
+                else -> DataStore.testUrl}
+            val url = URL(urlString)
+            if (url.protocol != "https")
+                throw MalformedURLException(getString(R.string.connection_test_url_non_https, urlString))
+            if (!URLUtil.isValidUrl(urlString) || !Patterns.WEB_URL.matcher(urlString).matches())
+                throw MalformedURLException(getString(R.string.connection_test_url_invalid, urlString))
+            val conn = (if (BaseService.usingVpnMode) url.openConnection() else
+                url.openConnection(Proxy(Proxy.Type.SOCKS,
+                        InetSocketAddress("127.0.0.1", DataStore.portProxy))))
+                    as HttpURLConnection
+            conn.setRequestProperty("Connection", "close")
+            conn.instanceFollowRedirects = false
+            conn.useCaches = false
+            try {
+                val start = SystemClock.elapsedRealtime()
+                val code = conn.responseCode
+                val elapsed = SystemClock.elapsedRealtime() - start
+                if (code == 204 || code == 200 && conn.responseLength == 0L)
+                    Pair(true, getString(R.string.connection_test_available, elapsed))
+                else throw IOException(getString(R.string.connection_test_error_status_code, code))
+            } catch (e: IOException) {
+                Pair(false, getString(R.string.connection_test_error, e.message))
+            } finally {
+                conn.disconnect()
+            }
+        } catch (e: MalformedURLException) {
+            Pair(false, getString(R.string.connection_test_url_error, e.message))
         }
         if (testCount == id) app.handler.post {
             if (success) statusText.text = result else {

--- a/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -54,9 +54,6 @@ object DataStore {
     var testUrl: String
         get() = publicStore.getString(Key.testUrl) ?: "https://www.google.com/generate_204"
         set(value) = publicStore.putString(Key.testUrl, value)
-    var testUrlChinaList: String
-        get() = publicStore.getString(Key.testUrlChinaList) ?: "https://www.qualcomm.cn/generate_204"
-        set(value) = publicStore.putString(Key.testUrlChinaList, value)
     var serviceMode: String
         get() = publicStore.getString(Key.serviceMode) ?: Key.modeVpn
         set(value) = publicStore.putString(Key.serviceMode, value)
@@ -73,7 +70,6 @@ object DataStore {
     fun initGlobal() {
         // temporary workaround for support lib bug
         if (publicStore.getString(Key.testUrl) == null) testUrl = testUrl
-        if (publicStore.getString(Key.testUrlChinaList) == null) testUrlChinaList = testUrlChinaList
         if (publicStore.getString(Key.serviceMode) == null) serviceMode = serviceMode
         if (publicStore.getString(Key.portProxy) == null) portProxy = portProxy
         if (publicStore.getString(Key.portLocalDns) == null) portLocalDns = portLocalDns

--- a/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -51,6 +51,12 @@ object DataStore {
         }
     val canToggleLocked: Boolean get() = publicStore.getBoolean(Key.directBootAware) == true
     val directBootAware: Boolean get() = app.directBootSupported && canToggleLocked
+    var testUrl: String
+        get() = publicStore.getString(Key.testUrl) ?: "https://www.google.com/generate_204"
+        set(value) = publicStore.putString(Key.testUrl, value)
+    var testUrlChinaList: String
+        get() = publicStore.getString(Key.testUrlChinaList) ?: "https://www.qualcomm.cn/generate_204"
+        set(value) = publicStore.putString(Key.testUrlChinaList, value)
     var serviceMode: String
         get() = publicStore.getString(Key.serviceMode) ?: Key.modeVpn
         set(value) = publicStore.putString(Key.serviceMode, value)
@@ -66,6 +72,8 @@ object DataStore {
 
     fun initGlobal() {
         // temporary workaround for support lib bug
+        if (publicStore.getString(Key.testUrl) == null) testUrl = testUrl
+        if (publicStore.getString(Key.testUrlChinaList) == null) testUrlChinaList = testUrlChinaList
         if (publicStore.getString(Key.serviceMode) == null) serviceMode = serviceMode
         if (publicStore.getString(Key.portProxy) == null) portProxy = portProxy
         if (publicStore.getString(Key.portLocalDns) == null) portLocalDns = portLocalDns

--- a/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
@@ -49,6 +49,8 @@ object Key {
     const val bypass = "isBypassApps"
     const val udpdns = "isUdpDns"
     const val ipv6 = "isIpv6"
+    const val testUrl = "testUrl"
+    const val testUrlChinaList = "testUrlChinaList"
 
     const val host = "proxy"
     const val password = "sitekey"

--- a/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
@@ -50,7 +50,6 @@ object Key {
     const val udpdns = "isUdpDns"
     const val ipv6 = "isIpv6"
     const val testUrl = "testUrl"
-    const val testUrlChinaList = "testUrlChinaList"
 
     const val host = "proxy"
     const val password = "sitekey"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
   <string name="stat_summary">Sent: \t\t\t\t\t%3$s\t↑\t%1$s\nReceived: \t%4$s\t↓\t%2$s</string>
   <string name="speed">%s/s</string>
   <string name="connection_test_url">Connection Test URL</string>
-  <string name="connection_test_url_chinalist">Connection Test URL (China List mode only)</string>
   <string name="connection_test_pending">Check Connectivity</string>
   <string name="connection_test_testing">Testing…</string>
   <string name="connection_test_available">Success: %dms latency</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -20,9 +20,14 @@
   <string name="traffic">%s↑\t%s↓</string>
   <string name="stat_summary">Sent: \t\t\t\t\t%3$s\t↑\t%1$s\nReceived: \t%4$s\t↓\t%2$s</string>
   <string name="speed">%s/s</string>
+  <string name="connection_test_url">Connection Test URL</string>
+  <string name="connection_test_url_chinalist">Connection Test URL (China List mode only)</string>
   <string name="connection_test_pending">Check Connectivity</string>
   <string name="connection_test_testing">Testing…</string>
   <string name="connection_test_available">Success: %dms latency</string>
+  <string name="connection_test_url_error">Check connection test URL. %s</string>
+  <string name="connection_test_url_non_https">Non-HTTPS URL: %s</string>
+  <string name="connection_test_url_invalid">Invalid URL: %s</string>
   <string name="connection_test_error">Fail to detect internet connection: %s</string>
   <string name="connection_test_fail">Internet Unavailable</string>
   <string name="connection_test_error_status_code">Error code: #%d</string>

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -16,10 +16,6 @@
         android:key="testUrl"
         android:title="@string/connection_test_url"
         app:pref_summaryHasText="%s"/>
-    <AutoSummaryEditTextPreference
-        android:key="testUrlChinaList"
-        android:title="@string/connection_test_url_chinalist"
-        app:pref_summaryHasText="%s"/>
     <PreferenceCategory
         android:title="@string/advanced">
         <SimpleMenuPreference

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -12,6 +12,14 @@
     <SwitchPreference android:key="tcp_fastopen"
                       android:summary="@string/tcp_fastopen_summary"
                       android:title="TCP Fast Open"/>
+    <AutoSummaryEditTextPreference
+        android:key="testUrl"
+        android:title="@string/connection_test_url"
+        app:pref_summaryHasText="%s"/>
+    <AutoSummaryEditTextPreference
+        android:key="testUrlChinaList"
+        android:title="@string/connection_test_url_chinalist"
+        app:pref_summaryHasText="%s"/>
     <PreferenceCategory
         android:title="@string/advanced">
         <SimpleMenuPreference


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [x] New feature
* [ ] Translation
* [ ] General refinement
* Other:

### Details

When SS is used in China as a pure secure proxy, the hardcoded connection test Google server may not work.
Here I added two global URL configuration, one for China List mode, one for else.


