### PR TITLE
Switch fragment after drawer is closed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,14 @@ apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
     ext {
-        kotlinVersion = '1.2.41'
+        kotlinVersion = '1.2.51'
         minSdkVersion = 21
         sdkVersion = 28
         compileSdkVersion = 28
         buildToolsVersion = '28.0.0'
         supportLibraryVersion = '28.0.0-alpha3'
         takisoftFixVersion = '27.1.1.1'
-        roomVersion = '1.1.0'
+        roomVersion = '1.1.1'
         junitVersion = '4.12'
         androidTestVersion = '1.0.2'
         androidEspressoVersion = '3.0.2'

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-vision:15.0.2"
     implementation "com.google.firebase:firebase-config:16.0.0"
     implementation 'com.google.firebase:firebase-core:16.0.0'
-    implementation 'com.mikepenz:materialdrawer:6.0.7'
+    implementation 'com.mikepenz:materialdrawer:6.0.8'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation "com.takisoft.fix:preference-v7-simplemenu:$takisoftFixVersion"
     implementation 'com.twofortyfouram:android-plugin-api-for-locale:1.0.2'


### PR DESCRIPTION
### Type of changes

_Put an `x` inside the [ ] that applies._

* [ ] Bugfix
* [ ] New feature
* [ ] Translation
* [x] General refinement
* Other:

### Details

在抽屉关闭之后再进行下一步 UI 操作，否则可能会出现卡顿，特别是在首次打开 AboutFragment 的时候，由于 WebView 的加载时间较长，抽屉回退时卡顿

