### PR TITLE
Remove night mode switch

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/App.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/App.kt
@@ -136,7 +136,7 @@ class App : Application() {
                 }
             DataStore.publicStore.putLong(Key.assetUpdateTime, info.lastUpdateTime)
         }
-        AppCompatDelegate.setDefaultNightMode(DataStore.nightMode)
+        if (Build.VERSION.SDK_INT < 28) AppCompatDelegate.setDefaultNightMode(DataStore.nightMode)
         updateNotificationChannels()
     }
 

--- a/mobile/src/main/java/com/github/shadowsocks/App.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/App.kt
@@ -136,7 +136,6 @@ class App : Application() {
                 }
             DataStore.publicStore.putLong(Key.assetUpdateTime, info.lastUpdateTime)
         }
-        if (Build.VERSION.SDK_INT < 28) AppCompatDelegate.setDefaultNightMode(DataStore.nightMode)
         updateNotificationChannels()
     }
 

--- a/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
@@ -64,7 +64,6 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
             tfo.isEnabled = false
             tfo.summary = getString(R.string.tcp_fastopen_summary_unsupported, System.getProperty("os.version"))
         }
-        if (Build.VERSION.SDK_INT >= 28) findPreference(Key.nightMode).remove()
 
         val serviceMode = findPreference(Key.serviceMode)
         val portProxy = findPreference(Key.portProxy)

--- a/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
@@ -30,6 +30,7 @@ import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.Key
 import com.github.shadowsocks.utils.TcpFastOpen
+import com.github.shadowsocks.utils.remove
 import com.takisoft.preferencex.PreferenceFragmentCompat
 
 class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
@@ -48,7 +49,7 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
         if (Build.VERSION.SDK_INT >= 24) canToggleLocked.setOnPreferenceChangeListener { _, newValue ->
             if (app.directBootSupported && newValue as Boolean) DirectBoot.update() else DirectBoot.clean()
             true
-        } else canToggleLocked.parent!!.removePreference(canToggleLocked)
+        } else canToggleLocked.remove()
 
         val tfo = findPreference(Key.tfo) as SwitchPreference
         tfo.isChecked = DataStore.tcpFastOpen
@@ -63,6 +64,7 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
             tfo.isEnabled = false
             tfo.summary = getString(R.string.tcp_fastopen_summary_unsupported, System.getProperty("os.version"))
         }
+        if (Build.VERSION.SDK_INT >= 28) findPreference(Key.nightMode).remove()
 
         val serviceMode = findPreference(Key.serviceMode)
         val portProxy = findPreference(Key.portProxy)

--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -30,6 +30,7 @@ import android.content.Intent
 import android.net.VpnService
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
@@ -184,7 +185,7 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, OnPre
 
         val intent = this.intent
         if (intent != null) handleShareIntent(intent)
-        if (savedInstanceState != null &&
+        if (Build.VERSION.SDK_INT < 28 && savedInstanceState != null &&
                 DataStore.nightMode == AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM &&
                 AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM) {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
@@ -226,7 +227,7 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, OnPre
                 connection.disconnect()
                 connection.connect()
             }
-            Key.nightMode -> {
+            Key.nightMode -> if (Build.VERSION.SDK_INT < 28) {
                 val mode = DataStore.nightMode
                 AppCompatDelegate.setDefaultNightMode(when (mode) {
                     AppCompatDelegate.getDefaultNightMode() -> return

--- a/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/MainActivity.kt
@@ -22,7 +22,6 @@ package com.github.shadowsocks
 
 import android.app.Activity
 import android.app.PendingIntent
-import android.app.UiModeManager
 import android.app.backup.BackupManager
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -30,18 +29,15 @@ import android.content.Intent
 import android.net.VpnService
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
-import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.core.view.GravityCompat
 import androidx.core.view.updateLayoutParams
@@ -185,11 +181,6 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, OnPre
 
         val intent = this.intent
         if (intent != null) handleShareIntent(intent)
-        if (Build.VERSION.SDK_INT < 28 && savedInstanceState != null &&
-                DataStore.nightMode == AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM &&
-                AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -226,15 +217,6 @@ class MainActivity : AppCompatActivity(), ShadowsocksConnection.Interface, OnPre
             Key.serviceMode -> app.handler.post {
                 connection.disconnect()
                 connection.connect()
-            }
-            Key.nightMode -> if (Build.VERSION.SDK_INT < 28) {
-                val mode = DataStore.nightMode
-                AppCompatDelegate.setDefaultNightMode(when (mode) {
-                    AppCompatDelegate.getDefaultNightMode() -> return
-                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM -> getSystemService<UiModeManager>()!!.nightMode
-                    else -> mode
-                })
-                recreate()
             }
         }
     }

--- a/mobile/src/main/java/com/github/shadowsocks/ProfileConfigFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/ProfileConfigFragment.kt
@@ -157,8 +157,7 @@ class ProfileConfigFragment : PreferenceFragmentCompat(), Toolbar.OnMenuItemClic
             val intent = PluginManager.buildIntent(pluginConfiguration.selected, PluginContract.ACTION_CONFIGURE)
             if (intent.resolveActivity(requireContext().packageManager) == null) showPluginEditor() else
                 startActivityForResult(intent
-                        .putExtra(PluginContract.EXTRA_OPTIONS, pluginConfiguration.selectedOptions.toString())
-                        .putExtra(PluginContract.EXTRA_NIGHT_MODE, DataStore.nightMode),
+                        .putExtra(PluginContract.EXTRA_OPTIONS, pluginConfiguration.selectedOptions.toString()),
                         REQUEST_CODE_PLUGIN_CONFIGURE)
         } else super.onDisplayPreferenceDialog(preference)
     }

--- a/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -21,8 +21,6 @@
 package com.github.shadowsocks.preference
 
 import android.os.Binder
-import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import com.github.shadowsocks.App.Companion.app
 import com.github.shadowsocks.database.PrivateDatabase
 import com.github.shadowsocks.database.PublicDatabase
@@ -55,13 +53,6 @@ object DataStore {
     val canToggleLocked: Boolean get() = publicStore.getBoolean(Key.directBootAware) == true
     val directBootAware: Boolean get() = app.directBootSupported && canToggleLocked
     val tcpFastOpen: Boolean get() = TcpFastOpen.sendEnabled && DataStore.publicStore.getBoolean(Key.tfo, true)
-    @AppCompatDelegate.NightMode
-    val nightMode get() = when (if (Build.VERSION.SDK_INT < 28) publicStore.getString(Key.nightMode) else null) {
-        Key.nightModeAuto -> AppCompatDelegate.MODE_NIGHT_AUTO
-        Key.nightModeOff -> AppCompatDelegate.MODE_NIGHT_NO
-        Key.nightModeOn -> AppCompatDelegate.MODE_NIGHT_YES
-        else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-    }
     val serviceMode get() = publicStore.getString(Key.serviceMode) ?: Key.modeVpn
     var portProxy: Int
         get() = getLocalPort(Key.portProxy, 1080)

--- a/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -21,6 +21,7 @@
 package com.github.shadowsocks.preference
 
 import android.os.Binder
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import com.github.shadowsocks.App.Companion.app
 import com.github.shadowsocks.database.PrivateDatabase
@@ -55,7 +56,7 @@ object DataStore {
     val directBootAware: Boolean get() = app.directBootSupported && canToggleLocked
     val tcpFastOpen: Boolean get() = TcpFastOpen.sendEnabled && DataStore.publicStore.getBoolean(Key.tfo, true)
     @AppCompatDelegate.NightMode
-    val nightMode get() = when (publicStore.getString(Key.nightMode)) {
+    val nightMode get() = when (if (Build.VERSION.SDK_INT < 28) publicStore.getString(Key.nightMode) else null) {
         Key.nightModeAuto -> AppCompatDelegate.MODE_NIGHT_AUTO
         Key.nightModeOff -> AppCompatDelegate.MODE_NIGHT_NO
         Key.nightModeOn -> AppCompatDelegate.MODE_NIGHT_YES

--- a/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/utils/Constants.kt
@@ -32,12 +32,6 @@ object Key {
 
     const val individual = "Proxyed"
 
-    const val nightMode = "nightMode"
-    const val nightModeSystem = "system"
-    const val nightModeAuto = "auto"
-    const val nightModeOff = "off"
-    const val nightModeOn = "on"
-
     const val serviceMode = "serviceMode"
     const val modeProxy = "proxy"
     const val modeVpn = "vpn"

--- a/mobile/src/main/java/com/github/shadowsocks/utils/Utils.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/utils/Utils.kt
@@ -12,6 +12,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.TypedValue
 import androidx.annotation.AttrRes
+import androidx.preference.Preference
 import com.crashlytics.android.Crashlytics
 import com.github.shadowsocks.JniHelper
 import java.net.InetAddress
@@ -68,3 +69,5 @@ fun printLog(t: Throwable) {
     Crashlytics.logException(t)
     t.printStackTrace()
 }
+
+fun Preference.remove() = parent!!.removePreference(this)

--- a/mobile/src/main/res/drawable/ic_image_brightness_3.xml
+++ b/mobile/src/main/res/drawable/ic_image_brightness_3.xml
@@ -1,6 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android"
-    android:tint="?attr/colorControlNormal">
-    <path android:fillColor="#FF000000" android:pathData="M9,2c-1.05,0 -2.05,0.16 -3,0.46 4.06,1.27 7,5.06 7,9.54 0,4.48 -2.94,8.27 -7,9.54 0.95,0.3 1.95,0.46 3,0.46 5.52,0 10,-4.48 10,-10S14.52,2 9,2z"/>
-</vector>

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -237,16 +237,4 @@
         <item>vpn</item>
         <item>transproxy</item>
     </string-array>
-    <string-array name="night_modes">
-        <item>@string/night_mode_system</item>
-        <item>@string/night_mode_auto</item>
-        <item>@string/night_mode_off</item>
-        <item>@string/night_mode_on</item>
-    </string-array>
-    <string-array name="night_mode_values" translatable="false">
-        <item>system</item>
-        <item>auto</item>
-        <item>off</item>
-        <item>on</item>
-    </string-array>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -57,11 +57,6 @@
   <string name="tcp_fastopen_summary_unsupported">Unsupported kernel version: %s &lt; 3.7.1</string>
   <string name="udp_dns">DNS Forwarding</string>
   <string name="udp_dns_summary">Forward all DNS requests to remote</string>
-  <string name="night_mode">Night mode</string>
-  <string name="night_mode_system">Follow system</string>
-  <string name="night_mode_auto">Auto</string>
-  <string name="night_mode_on">On</string>
-  <string name="night_mode_off">Off</string>
 
   <!-- notification category -->
   <string name="service_vpn">VPN Service</string>

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -15,14 +15,6 @@
         android:icon="@drawable/ic_action_offline_bolt"
         android:summary="@string/tcp_fastopen_summary"
         android:title="TCP Fast Open"/>
-    <SimpleMenuPreference
-        android:key="nightMode"
-        android:icon="@drawable/ic_image_brightness_3"
-        android:entries="@array/night_modes"
-        android:entryValues="@array/night_mode_values"
-        android:defaultValue="system"
-        android:summary="%s"
-        android:title="@string/night_mode"/>
     <PreferenceCategory
         android:title="@string/advanced">
         <SimpleMenuPreference

--- a/plugin/src/main/java/com/github/shadowsocks/plugin/OptionsCapableActivity.kt
+++ b/plugin/src/main/java/com/github/shadowsocks/plugin/OptionsCapableActivity.kt
@@ -24,7 +24,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.app.AppCompatDelegate
 
 /**
  * Activity that's capable of getting EXTRA_OPTIONS input.
@@ -43,13 +42,6 @@ abstract class OptionsCapableActivity : AppCompatActivity() {
      * @param options PluginOptions parsed.
      */
     protected abstract fun onInitializePluginOptions(options: PluginOptions = pluginOptions())
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        val nightMode = intent.getIntExtra(PluginContract.EXTRA_NIGHT_MODE, -100)   // MODE_NIGHT_UNSPECIFIED
-        if (nightMode >= AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM && nightMode <= AppCompatDelegate.MODE_NIGHT_YES)
-            AppCompatDelegate.setDefaultNightMode(nightMode)
-        super.onCreate(savedInstanceState)  // applyDayNight is called in AppCompatActivity.onCreate
-    }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)

--- a/plugin/src/main/java/com/github/shadowsocks/plugin/PluginContract.kt
+++ b/plugin/src/main/java/com/github/shadowsocks/plugin/PluginContract.kt
@@ -20,8 +20,6 @@
 
 package com.github.shadowsocks.plugin
 
-import androidx.appcompat.app.AppCompatDelegate
-
 /**
  * The contract between the plugin provider and host. Contains definitions for the supported actions, extras, etc.
  *
@@ -73,14 +71,6 @@ object PluginContract {
      * Constant Value: "com.github.shadowsocks.plugin.EXTRA_HELP_MESSAGE"
     </host_name> */
     const val EXTRA_HELP_MESSAGE = "com.github.shadowsocks.plugin.EXTRA_HELP_MESSAGE"
-    /**
-     * The lookup key for an @NightMode int that suggests a night mode that is being used in the main app.
-     *
-     * Constant Value: "com.github.shadowsocks.plugin.EXTRA_NIGHT_MODE"
-     */
-    @AppCompatDelegate.NightMode
-    @Deprecated("On Android 9.0+, this will always return system as AOSP has support for night mode since 9.0.")
-    const val EXTRA_NIGHT_MODE = "com.github.shadowsocks.plugin.EXTRA_NIGHT_MODE"
 
     /**
      * The metadata key to retrieve plugin id. Required for plugins.

--- a/plugin/src/main/java/com/github/shadowsocks/plugin/PluginContract.kt
+++ b/plugin/src/main/java/com/github/shadowsocks/plugin/PluginContract.kt
@@ -79,6 +79,7 @@ object PluginContract {
      * Constant Value: "com.github.shadowsocks.plugin.EXTRA_NIGHT_MODE"
      */
     @AppCompatDelegate.NightMode
+    @Deprecated("On Android 9.0+, this will always return system as AOSP has support for night mode since 9.0.")
     const val EXTRA_NIGHT_MODE = "com.github.shadowsocks.plugin.EXTRA_NIGHT_MODE"
 
     /**


### PR DESCRIPTION
It seems that Android 9.0 has finally supported Night mode officially. Unfortunately it doesn't work on emulator (not on my side) so I'm not sure if this works.

@onlymash Please review.