### PR TITLE
Implement UDP fallback

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,6 +40,10 @@ android {
             path 'src/main/jni/Android.mk'
         }
     }
+
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
+    }
 }
 
 task goBuild(type: Exec) {
@@ -83,9 +87,10 @@ dependencies {
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     testImplementation "androidx.arch.core:core-testing:$lifecycleVersion"
-    testImplementation "androidx.room:room-testing:$roomVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "android.arch.work:work-testing:$workVersion"
+    androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestImplementation "androidx.test:runner:$androidTestVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidEspressoVersion"
+    androidTestImplementation "androidx.test.ext:junit-ktx:1.1.0"
 }

--- a/core/schemas/com.github.shadowsocks.database.PrivateDatabase/27.json
+++ b/core/schemas/com.github.shadowsocks.database.PrivateDatabase/27.json
@@ -1,0 +1,167 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 27,
+    "identityHash": "8743c2e56bdbdabca7fcb89dff5434ba",
+    "entities": [
+      {
+        "tableName": "Profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `host` TEXT NOT NULL, `remotePort` INTEGER NOT NULL, `password` TEXT NOT NULL, `method` TEXT NOT NULL, `route` TEXT NOT NULL, `remoteDns` TEXT NOT NULL, `proxyApps` INTEGER NOT NULL, `bypass` INTEGER NOT NULL, `udpdns` INTEGER NOT NULL, `ipv6` INTEGER NOT NULL, `individual` TEXT NOT NULL, `tx` INTEGER NOT NULL, `rx` INTEGER NOT NULL, `userOrder` INTEGER NOT NULL, `plugin` TEXT, `udpFallback` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePort",
+            "columnName": "remotePort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "method",
+            "columnName": "method",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "route",
+            "columnName": "route",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteDns",
+            "columnName": "remoteDns",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proxyApps",
+            "columnName": "proxyApps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bypass",
+            "columnName": "bypass",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "udpdns",
+            "columnName": "udpdns",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ipv6",
+            "columnName": "ipv6",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "individual",
+            "columnName": "individual",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tx",
+            "columnName": "tx",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rx",
+            "columnName": "rx",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userOrder",
+            "columnName": "userOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plugin",
+            "columnName": "plugin",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "udpFallback",
+            "columnName": "udpFallback",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "KeyValuePair",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `valueType` INTEGER NOT NULL, `value` BLOB NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "valueType",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"8743c2e56bdbdabca7fcb89dff5434ba\")"
+    ]
+  }
+}

--- a/core/src/androidTest/java/com/github/shadowsocks/database/MigrationTest.kt
+++ b/core/src/androidTest/java/com/github/shadowsocks/database/MigrationTest.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *                                                                             *
- *  Copyright (C) 2017 by Max Lv <max.c.lv@gmail.com>                          *
- *  Copyright (C) 2017 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
  *                                                                             *
  *  This program is free software: you can redistribute it and/or modify       *
  *  it under the terms of the GNU General Public License as published by       *
@@ -18,27 +18,32 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.bg
+package com.github.shadowsocks.database
 
-import android.net.LocalSocket
-import com.github.shadowsocks.Core
-import com.github.shadowsocks.utils.printLog
-import java.io.File
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
 import java.io.IOException
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
-class TrafficMonitorThread : LocalSocketListener("TrafficMonitorThread") {
-    override val socketFile = File(Core.deviceStorage.noBackupFilesDir, "stat_path")
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+    companion object {
+        private const val TEST_DB = "migration-test"
+    }
 
-    override fun accept(socket: LocalSocket) {
-        try {
-            val buffer = ByteArray(16)
-            if (socket.inputStream.read(buffer) != 16) throw IOException("Unexpected traffic stat length")
-            val stat = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN)
-            TrafficMonitor.update(stat.getLong(0), stat.getLong(8))
-        } catch (e: IOException) {
-            printLog(e)
-        }
+    @get:Rule
+    val privateDatabase = MigrationTestHelper(InstrumentationRegistry.getInstrumentation(),
+            PrivateDatabase::class.java.canonicalName, FrameworkSQLiteOpenHelperFactory())
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate27() {
+        val db = privateDatabase.createDatabase(TEST_DB, 26)
+        db.close()
+        privateDatabase.runMigrationsAndValidate(TEST_DB, 27, true, PrivateDatabase.Migration27)
     }
 }

--- a/core/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksServiceCallback.aidl
+++ b/core/src/main/aidl/com/github/shadowsocks/aidl/IShadowsocksServiceCallback.aidl
@@ -1,8 +1,10 @@
 package com.github.shadowsocks.aidl;
 
+import com.github.shadowsocks.aidl.TrafficStats;
+
 interface IShadowsocksServiceCallback {
   oneway void stateChanged(int state, String profileName, String msg);
-  oneway void trafficUpdated(long profileId, long txRate, long rxRate, long txTotal, long rxTotal);
+  oneway void trafficUpdated(long profileId, in TrafficStats stats);
   // Traffic data has persisted to database, listener should refetch their data from database
   oneway void trafficPersisted(long profileId);
 }

--- a/core/src/main/aidl/com/github/shadowsocks/aidl/TrafficStats.aidl
+++ b/core/src/main/aidl/com/github/shadowsocks/aidl/TrafficStats.aidl
@@ -1,0 +1,3 @@
+package com.github.shadowsocks.aidl;
+
+parcelable TrafficStats;

--- a/core/src/main/java/com/github/shadowsocks/Core.kt
+++ b/core/src/main/java/com/github/shadowsocks/Core.kt
@@ -69,8 +69,13 @@ object Core {
                 DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER
     }
 
-    val currentProfile: Profile? get() =
-        if (DataStore.directBootAware) DirectBoot.getDeviceProfile() else ProfileManager.getProfile(DataStore.profileId)
+    val activeProfileIds get() = ProfileManager.getProfile(DataStore.profileId).let {
+        if (it == null) emptyList() else listOfNotNull(it.id, it.udpFallback)
+    }
+    val currentProfile: Pair<Profile, Profile?>? get() {
+        if (DataStore.directBootAware) DirectBoot.getDeviceProfile()?.apply { return this }
+        return ProfileManager.expand(ProfileManager.getProfile(DataStore.profileId) ?: return null)
+    }
 
     fun switchProfile(id: Long): Profile {
         val result = ProfileManager.getProfile(id) ?: ProfileManager.createProfile()

--- a/core/src/main/java/com/github/shadowsocks/aidl/TrafficStats.kt
+++ b/core/src/main/java/com/github/shadowsocks/aidl/TrafficStats.kt
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *                                                                             *
- *  Copyright (C) 2017 by Max Lv <max.c.lv@gmail.com>                          *
- *  Copyright (C) 2017 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
  *                                                                             *
  *  This program is free software: you can redistribute it and/or modify       *
  *  it under the terms of the GNU General Public License as published by       *
@@ -18,29 +18,35 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks
+package com.github.shadowsocks.aidl
 
-import android.os.Bundle
-import android.view.View
-import androidx.appcompat.widget.Toolbar
-import androidx.core.view.GravityCompat
-import androidx.fragment.app.Fragment
-import com.github.shadowsocks.aidl.TrafficStats
+import android.os.Parcel
+import android.os.Parcelable
 
-/**
- * @author Mygod
- */
-open class ToolbarFragment : Fragment() {
-    lateinit var toolbar: Toolbar
+data class TrafficStats(
+        // Bytes per second
+        var txRate: Long = 0L,
+        var rxRate: Long = 0L,
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        toolbar = view.findViewById(R.id.toolbar)
-        toolbar.setNavigationIcon(R.drawable.ic_navigation_menu)
-        toolbar.setNavigationOnClickListener { (activity as MainActivity).drawer.openDrawer(GravityCompat.START) }
+        // Bytes for the current session
+        var txTotal: Long = 0L,
+        var rxTotal: Long = 0L
+): Parcelable {
+    operator fun plus(other: TrafficStats) = TrafficStats(
+            txRate + other.txRate, rxRate + other.rxRate,
+            txTotal + other.txTotal, rxTotal + other.rxTotal)
+
+    constructor(parcel: Parcel) : this(parcel.readLong(), parcel.readLong(), parcel.readLong(), parcel.readLong())
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeLong(txRate)
+        parcel.writeLong(rxRate)
+        parcel.writeLong(txTotal)
+        parcel.writeLong(rxTotal)
     }
+    override fun describeContents() = 0
 
-    open fun onTrafficUpdated(profileId: Long, stats: TrafficStats) { }
-
-    open fun onBackPressed(): Boolean = false
+    companion object CREATOR : Parcelable.Creator<TrafficStats> {
+        override fun createFromParcel(parcel: Parcel) = TrafficStats(parcel)
+        override fun newArray(size: Int): Array<TrafficStats?> = arrayOfNulls(size)
+    }
 }

--- a/core/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
@@ -35,7 +35,7 @@ object LocalDnsService {
         override fun startNativeProcesses() {
             super.startNativeProcesses()
             val data = data
-            val profile = data.profile!!
+            val profile = data.proxy!!.profile
 
             fun makeDns(name: String, address: String, timeout: Int, edns: Boolean = true) = JSONObject().apply {
                 put("Name", name)

--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package com.github.shadowsocks.bg
+
+import android.content.Context
+import android.util.Base64
+import com.github.shadowsocks.Core
+import com.github.shadowsocks.acl.Acl
+import com.github.shadowsocks.acl.AclSyncer
+import com.github.shadowsocks.database.Profile
+import com.github.shadowsocks.database.ProfileManager
+import com.github.shadowsocks.plugin.PluginConfiguration
+import com.github.shadowsocks.plugin.PluginManager
+import com.github.shadowsocks.preference.DataStore
+import com.github.shadowsocks.utils.*
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class sets up environment for ss-local.
+ */
+class ProxyInstance(val profile: Profile, private val route: String = profile.route): AutoCloseable {
+    var configFile: File? = null
+    var trafficMonitor: TrafficMonitor? = null
+    private val plugin = PluginConfiguration(profile.plugin ?: "").selectedOptions
+    val pluginPath by lazy { PluginManager.init(plugin) }
+
+    fun init() {
+        if (profile.host == "198.199.101.152") {
+            val client = OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .build()
+            val mdg = MessageDigest.getInstance("SHA-1")
+            mdg.update(Core.packageInfo.signaturesCompat.first().toByteArray())
+            val requestBody = FormBody.Builder()
+                    .add("sig", String(Base64.encode(mdg.digest(), 0)))
+                    .build()
+            val request = Request.Builder()
+                    .url(RemoteConfig.proxyUrl)
+                    .post(requestBody)
+                    .build()
+
+            val proxies = client.newCall(request).execute()
+                    .body()!!.string().split('|').toMutableList()
+            proxies.shuffle()
+            val proxy = proxies.first().split(':')
+            profile.host = proxy[0].trim()
+            profile.remotePort = proxy[1].trim().toInt()
+            profile.password = proxy[2].trim()
+            profile.method = proxy[3].trim()
+        }
+
+        if (route == Acl.CUSTOM_RULES) Acl.save(Acl.CUSTOM_RULES, Acl.customRules.flatten(10))
+
+        // it's hard to resolve DNS on a specific interface so we'll do it here
+        if (!profile.host.isNumericAddress()) {
+            thread("ProxyInstance-resolve") {
+                // A WAR fix for Huawei devices that UnknownHostException cannot be caught correctly
+                try {
+                    profile.host = InetAddress.getByName(profile.host).hostAddress ?: ""
+                } catch (_: UnknownHostException) { }
+            }.join(10 * 1000)
+            if (!profile.host.isNumericAddress()) throw UnknownHostException()
+        }
+    }
+
+    /**
+     * Sensitive shadowsocks configuration file requires extra protection. It may be stored in encrypted storage or
+     * device storage, depending on which is currently available.
+     */
+    fun start(service: BaseService.Interface, stat: File, configFile: File, extraFlag: String? = null) {
+        trafficMonitor = TrafficMonitor(stat)
+
+        this.configFile = configFile
+        val config = profile.toJson()
+        if (pluginPath != null) {
+            val pluginCmd = arrayListOf(pluginPath!!)
+            if (DataStore.tcpFastOpen) pluginCmd.add("--fast-open")
+            config
+                    .put("plugin", Commandline.toString(service.buildAdditionalArguments(pluginCmd)))
+                    .put("plugin_opts", plugin.toString())
+        }
+        configFile.writeText(config.toString())
+
+        val cmd = service.buildAdditionalArguments(arrayListOf(
+                File((service as Context).applicationInfo.nativeLibraryDir, Executable.SS_LOCAL).absolutePath,
+                "-b", DataStore.listenAddress,
+                "-l", DataStore.portProxy.toString(),
+                "-t", "600",
+                "-S", stat.absolutePath,
+                "-c", configFile.absolutePath))
+        if (extraFlag != null) cmd.add(extraFlag)
+
+        if (route != Acl.ALL) {
+            cmd += "--acl"
+            cmd += Acl.getFile(route).absolutePath
+        }
+
+        // for UDP profile, it's only going to operate in UDP relay mode-only so this flag has no effect
+        if (profile.udpdns) cmd += "-D"
+
+        if (DataStore.tcpFastOpen) cmd += "--fast-open"
+
+        service.data.processes.start(cmd)
+    }
+
+    fun scheduleUpdate() {
+        if (route !in arrayOf(Acl.ALL, Acl.CUSTOM_RULES)) AclSyncer.schedule(route)
+    }
+
+    override fun close() {
+        trafficMonitor?.apply {
+            close()
+            // Make sure update total traffic when stopping the runner
+            try {
+                // profile may have host, etc. modified and thus a re-fetch is necessary (possible race condition)
+                val profile = ProfileManager.getProfile(profile.id) ?: return
+                profile.tx += current.txTotal
+                profile.rx += current.rxTotal
+                ProfileManager.updateProfile(profile)
+            } catch (e: IOException) {
+                if (!DataStore.directBootAware) throw e // we should only reach here because we're in direct boot
+                val profile = DirectBoot.getDeviceProfile()!!.toList().filterNotNull().single { it.id == profile.id }
+                profile.tx += current.txTotal
+                profile.rx += current.rxTotal
+                profile.dirty = true
+                DirectBoot.update(profile)
+                DirectBoot.listenForUnlock()
+            }
+        }
+        trafficMonitor = null
+        configFile?.delete()    // remove old config possibly in device storage
+        configFile = null
+    }
+}

--- a/core/src/main/java/com/github/shadowsocks/bg/ServiceNotification.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ServiceNotification.kt
@@ -35,10 +35,10 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import com.github.shadowsocks.Core
 import com.github.shadowsocks.aidl.IShadowsocksServiceCallback
+import com.github.shadowsocks.aidl.TrafficStats
 import com.github.shadowsocks.core.R
 import com.github.shadowsocks.utils.Action
 import com.github.shadowsocks.utils.broadcastReceiver
-import java.util.*
 
 /**
  * Android < 8 VPN:     always invisible because of VPN notification/icon
@@ -53,13 +53,15 @@ class ServiceNotification(private val service: BaseService.Interface, profileNam
     private val callback: IShadowsocksServiceCallback by lazy {
         object : IShadowsocksServiceCallback.Stub() {
             override fun stateChanged(state: Int, profileName: String?, msg: String?) { }   // ignore
-            override fun trafficUpdated(profileId: Long, txRate: Long, rxRate: Long, txTotal: Long, rxTotal: Long) {
+            override fun trafficUpdated(profileId: Long, stats: TrafficStats) {
+                if (profileId != 0L) return
                 service as Context
-                val txr = service.getString(R.string.speed, Formatter.formatFileSize(service, txRate))
-                val rxr = service.getString(R.string.speed, Formatter.formatFileSize(service, rxRate))
+                val txr = service.getString(R.string.speed, Formatter.formatFileSize(service, stats.txRate))
+                val rxr = service.getString(R.string.speed, Formatter.formatFileSize(service, stats.rxRate))
                 builder.setContentText("$txr↑\t$rxr↓")
                 style.bigText(service.getString(R.string.stat_summary, txr, rxr,
-                        Formatter.formatFileSize(service, txTotal), Formatter.formatFileSize(service, rxTotal)))
+                        Formatter.formatFileSize(service, stats.txTotal),
+                        Formatter.formatFileSize(service, stats.rxTotal)))
                 show()
             }
             override fun trafficPersisted(profileId: Long) { }

--- a/core/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
@@ -40,13 +40,14 @@ class TransproxyService : Service(), LocalDnsService.Interface {
             super<LocalDnsService.Interface>.onStartCommand(intent, flags, startId)
 
     private fun startDNSTunnel() {
+        val proxy = data.proxy!!
         val cmd = arrayListOf(File(applicationInfo.nativeLibraryDir, Executable.SS_TUNNEL).absolutePath,
                 "-t", "10",
                 "-b", DataStore.listenAddress,
                 "-u",
-                "-l", DataStore.portLocalDns.toString(),            // ss-tunnel listens on the same port as overture
-                "-L", data.profile!!.remoteDns.split(",").first().trim() + ":53",
-                "-c", data.shadowsocksConfigFile!!.absolutePath)    // config is already built by BaseService.Interface
+                "-l", DataStore.portLocalDns.toString(),    // ss-tunnel listens on the same port as overture
+                "-L", proxy.profile.remoteDns.split(",").first().trim() + ":53",
+                "-c", proxy.configFile!!.absolutePath)      // config is already built by BaseService.Interface
         if (DataStore.tcpFastOpen) cmd += "--fast-open"
         data.processes.start(cmd)
     }
@@ -74,6 +75,6 @@ redsocks {
     override fun startNativeProcesses() {
         startRedsocksDaemon()
         super.startNativeProcesses()
-        if (data.profile!!.udpdns) startDNSTunnel()
+        if (data.proxy!!.profile.udpdns) startDNSTunnel()
     }
 }

--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -186,7 +186,7 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
     }
 
     private fun startVpn(): Int {
-        val profile = data.profile!!
+        val profile = data.proxy!!.profile
         val builder = Builder()
                 .setConfigureIntent(Core.configureIntent(this))
                 .setSession(profile.formattedName)

--- a/core/src/main/java/com/github/shadowsocks/database/Profile.kt
+++ b/core/src/main/java/com/github/shadowsocks/database/Profile.kt
@@ -102,16 +102,18 @@ class Profile : Serializable {
         }.filterNotNull()
 
         private class JsonParser(private val feature: Profile? = null) : ArrayList<Profile>() {
-            private fun tryAdd(json: JSONObject) {
+            private val fallbackMap = mutableMapOf<Profile, Profile>()
+
+            private fun tryParse(json: JSONObject, fallback: Boolean = false): Profile? {
                 val host = json.optString("server")
-                if (host.isNullOrEmpty()) return
+                if (host.isNullOrEmpty()) return null
                 val remotePort = json.optInt("server_port")
-                if (remotePort <= 0) return
+                if (remotePort <= 0) return null
                 val password = json.optString("password")
-                if (password.isNullOrEmpty()) return
+                if (password.isNullOrEmpty()) return null
                 val method = json.optString("method")
-                if (method.isNullOrEmpty()) return
-                add(Profile().also {
+                if (method.isNullOrEmpty()) return null
+                return Profile().also {
                     it.host = host
                     it.remotePort = remotePort
                     it.password = password
@@ -124,6 +126,7 @@ class Profile : Serializable {
                     }
                     name = json.optString("remarks")
                     route = json.optString("route", route)
+                    if (fallback) return@apply
                     remoteDns = json.optString("remote_dns", remoteDns)
                     ipv6 = json.optBoolean("ipv6", ipv6)
                     json.optJSONObject("proxy_apps")?.also {
@@ -132,22 +135,41 @@ class Profile : Serializable {
                         individual = it.optJSONArray("android_list")?.asIterable()?.joinToString("\n") ?: individual
                     }
                     udpdns = json.optBoolean("udpdns", udpdns)
-                })
+                    json.optJSONObject("udp_fallback")?.let { tryParse(it, true) }?.also { fallbackMap[this] = it }
+                }
             }
 
             fun process(json: Any) {
                 when (json) {
                     is JSONObject -> {
-                        tryAdd(json)
-                        for (key in json.keys()) process(json.get(key))
+                        val profile = tryParse(json)
+                        if (profile != null) add(profile) else for (key in json.keys()) process(json.get(key))
                     }
                     is JSONArray -> json.asIterable().forEach(this::process)
                     // ignore other types
                 }
             }
+            fun finalize(create: (Profile) -> Unit) {
+                val profiles = ProfileManager.getAllProfiles() ?: emptyList()
+                for ((profile, fallback) in fallbackMap) {
+                    val match = profiles.firstOrNull {
+                        fallback.host == it.host && fallback.remotePort == it.remotePort &&
+                                fallback.password == it.password && fallback.method == it.method &&
+                                it.plugin.isNullOrEmpty()
+                    }
+                    profile.udpFallback = if (match == null) {
+                        create(fallback)
+                        fallback.id
+                    } else match.id
+                    ProfileManager.updateProfile(profile)
+                }
+            }
         }
-        fun parseJson(json: String, feature: Profile? = null): List<Profile> =
-                JsonParser(feature).apply { process(JSONTokener(json).nextValue()) }
+        fun parseJson(json: String, feature: Profile? = null, create: (Profile) -> Unit) = JsonParser(feature).run {
+            process(JSONTokener(json).nextValue())
+            for (profile in this) create(profile)
+            finalize(create)
+        }
     }
 
     @androidx.room.Dao
@@ -195,6 +217,7 @@ class Profile : Serializable {
     var rx: Long = 0
     var userOrder: Long = 0
     var plugin: String? = null
+    var udpFallback: Long? = null
 
     @Ignore // not persisted in db, only used by direct boot
     var dirty: Boolean = false
@@ -226,12 +249,12 @@ class Profile : Serializable {
     }
     override fun toString() = toUri().toString()
 
-    fun toJson(compat: Boolean = false) = JSONObject().apply {
+    fun toJson(profiles: Map<Long, Profile>? = null): JSONObject = JSONObject().apply {
         put("server", host)
         put("server_port", remotePort)
         put("password", password)
         put("method", method)
-        if (compat) return@apply
+        if (profiles == null) return@apply
         PluginConfiguration(plugin ?: "").selectedOptions.also {
             if (it.id.isNotEmpty()) {
                 put("plugin", it.id)
@@ -251,9 +274,12 @@ class Profile : Serializable {
             }
         })
         put("udpdns", udpdns)
+        val fallback = profiles[udpFallback]
+        if (fallback != null && fallback.plugin.isNullOrEmpty()) fallback.toJson().also { put("udp_fallback", it) }
     }
 
     fun serialize() {
+        DataStore.editingId = id
         DataStore.privateStore.putString(Key.name, name)
         DataStore.privateStore.putString(Key.host, host)
         DataStore.privateStore.putString(Key.remotePort, remotePort.toString())
@@ -267,9 +293,12 @@ class Profile : Serializable {
         DataStore.privateStore.putBoolean(Key.ipv6, ipv6)
         DataStore.individual = individual
         DataStore.plugin = plugin ?: ""
+        DataStore.udpFallback = udpFallback
         DataStore.privateStore.remove(Key.dirty)
     }
     fun deserialize() {
+        check(id == 0L || DataStore.editingId == id)
+        DataStore.editingId = null
         // It's assumed that default values are never used, so 0/false/null is always used even if that isn't the case
         name = DataStore.privateStore.getString(Key.name) ?: ""
         host = DataStore.privateStore.getString(Key.host) ?: ""
@@ -284,5 +313,6 @@ class Profile : Serializable {
         ipv6 = DataStore.privateStore.getBoolean(Key.ipv6, false)
         individual = DataStore.individual
         plugin = DataStore.plugin
+        udpFallback = DataStore.udpFallback
     }
 }

--- a/core/src/main/java/com/github/shadowsocks/database/ProfileManager.kt
+++ b/core/src/main/java/com/github/shadowsocks/database/ProfileManager.kt
@@ -21,6 +21,7 @@
 package com.github.shadowsocks.database
 
 import android.database.sqlite.SQLiteCantOpenDatabaseException
+import com.github.shadowsocks.Core
 import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.printLog
@@ -63,11 +64,14 @@ object ProfileManager {
         null
     }
 
+    @Throws(IOException::class)
+    fun expand(profile: Profile): Pair<Profile, Profile?> = Pair(profile, profile.udpFallback?.let { getProfile(it) })
+
     @Throws(SQLException::class)
     fun delProfile(id: Long) {
         check(PrivateDatabase.profileDao.delete(id) == 1)
         listener?.onRemove(id)
-        if (id == DataStore.profileId && DataStore.directBootAware) DirectBoot.clean()
+        if (id in Core.activeProfileIds && DataStore.directBootAware) DirectBoot.clean()
     }
 
     @Throws(SQLException::class)

--- a/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -105,6 +105,9 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         if (publicStore.getString(Key.portTransproxy) == null) portTransproxy = portTransproxy
     }
 
+    var editingId: Long?
+        get() = privateStore.getLong(Key.id)
+        set(value) = privateStore.putLong(Key.id, value)
     var proxyApps: Boolean
         get() = privateStore.getBoolean(Key.proxyApps) ?: false
         set(value) = privateStore.putBoolean(Key.proxyApps, value)
@@ -117,6 +120,9 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var plugin: String
         get() = privateStore.getString(Key.plugin) ?: ""
         set(value) = privateStore.putString(Key.plugin, value)
+    var udpFallback: Long?
+        get() = privateStore.getLong(Key.udpFallback)
+        set(value) = privateStore.putLong(Key.udpFallback, value)
     var dirty: Boolean
         get() = privateStore.getBoolean(Key.dirty) ?: false
         set(value) = privateStore.putBoolean(Key.dirty, value)

--- a/core/src/main/java/com/github/shadowsocks/utils/Constants.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/Constants.kt
@@ -59,6 +59,7 @@ object Key {
 
     const val plugin = "plugin"
     const val pluginConfigure = "plugin.configure"
+    const val udpFallback = "udpFallback"
 
     const val dirty = "profileDirty"
 

--- a/core/src/main/java/com/github/shadowsocks/utils/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/HttpsTest.kt
@@ -80,7 +80,7 @@ class HttpsTest : ViewModel() {
         status.value = Status.Testing
         val id = testCount  // it would change by other code
         thread("ConnectionTest") {
-            val url = URL("https", when (Core.currentProfile!!.route) {
+            val url = URL("https", when (Core.currentProfile!!.first.route) {
                 Acl.CHINALIST -> "www.qualcomm.cn"
                 else -> "www.google.com"
             }, "/generate_204")

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
   <string name="tcp_fastopen_failure">Toggle failed</string>
   <string name="udp_dns">DNS Forwarding</string>
   <string name="udp_dns_summary">Forward all DNS requests to remote</string>
+  <string name="udp_fallback">UDP Fallback</string>
 
   <!-- notification category -->
   <string name="service_vpn">VPN Service</string>

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -59,6 +59,13 @@
             android:launchMode="singleTask"/>
 
         <activity
+            android:name=".UdpFallbackProfileActivity"
+            android:label="@string/udp_fallback"
+            android:parentActivityName=".ProfileConfigActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"/>
+
+        <activity
             android:name=".ScannerActivity"
             android:label="@string/add_profile_methods_scan_qr_code"
             android:parentActivityName=".MainActivity"

--- a/mobile/src/main/java/com/github/shadowsocks/ScannerActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/ScannerActivity.kt
@@ -105,7 +105,7 @@ class ScannerActivity : AppCompatActivity(), BarcodeRetriever {
     }
 
     override fun onRetrieved(barcode: Barcode) = runOnUiThread {
-        Profile.findAllUrls(barcode.rawValue, Core.currentProfile).forEach { ProfileManager.createProfile(it) }
+        Profile.findAllUrls(barcode.rawValue, Core.currentProfile?.first).forEach { ProfileManager.createProfile(it) }
         onSupportNavigateUp()
     }
     override fun onRetrievedMultiple(closetToClick: Barcode?, barcode: MutableList<BarcodeGraphic>?) = check(false)
@@ -136,7 +136,7 @@ class ScannerActivity : AppCompatActivity(), BarcodeRetriever {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when (requestCode) {
             REQUEST_IMPORT, REQUEST_IMPORT_OR_FINISH -> if (resultCode == Activity.RESULT_OK) {
-                val feature = Core.currentProfile
+                val feature = Core.currentProfile?.first
                 var success = false
                 for (uri in data!!.datas) try {
                     detector.detect(Frame.Builder().setBitmap(contentResolver.openBitmap(uri)).build())

--- a/mobile/src/main/java/com/github/shadowsocks/UdpFallbackProfileActivity.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/UdpFallbackProfileActivity.kt
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package com.github.shadowsocks
+
+import android.content.res.Resources
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckedTextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.shadowsocks.database.Profile
+import com.github.shadowsocks.database.ProfileManager
+import com.github.shadowsocks.preference.DataStore
+import com.github.shadowsocks.utils.resolveResourceId
+
+class UdpFallbackProfileActivity : AppCompatActivity() {
+    inner class ProfileViewHolder(view: View) : RecyclerView.ViewHolder(view), View.OnClickListener {
+        private var item: Profile? = null
+        private val text = itemView.findViewById<CheckedTextView>(android.R.id.text1)
+
+        init {
+            view.setBackgroundResource(theme.resolveResourceId(android.R.attr.selectableItemBackground))
+            itemView.setOnClickListener(this)
+        }
+
+        fun bind(item: Profile?) {
+            this.item = item
+            if (item == null) text.setText(R.string.plugin_disabled) else text.text = item.formattedName
+            text.isChecked = udpFallback == item?.id
+        }
+
+        override fun onClick(v: View?) {
+            DataStore.udpFallback = item?.id
+            DataStore.dirty = true
+            finish()
+        }
+    }
+
+    inner class ProfilesAdapter : RecyclerView.Adapter<ProfileViewHolder>() {
+        internal val profiles = (ProfileManager.getAllProfiles()?.toMutableList() ?: mutableListOf())
+                .filter { it.id != editingId && it.plugin.isNullOrEmpty() }
+
+        override fun onBindViewHolder(holder: ProfileViewHolder, position: Int) =
+                holder.bind(if (position == 0) null else profiles[position - 1])
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProfileViewHolder = ProfileViewHolder(
+                LayoutInflater.from(parent.context).inflate(Resources.getSystem()
+                        .getIdentifier("select_dialog_singlechoice_material", "layout", "android"), parent, false))
+        override fun getItemCount(): Int = 1 + profiles.size
+    }
+
+    private var editingId = DataStore.editingId
+    private var udpFallback = DataStore.udpFallback
+    private val profilesAdapter = ProfilesAdapter()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        if (editingId == null) {
+            finish()
+            return
+        }
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.layout_udp_fallback)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar.setTitle(R.string.udp_fallback)
+        toolbar.setNavigationIcon(R.drawable.ic_navigation_close)
+        toolbar.setNavigationOnClickListener { finish() }
+
+        val profilesList = findViewById<RecyclerView>(R.id.list)
+        val lm = LinearLayoutManager(this, RecyclerView.VERTICAL, false)
+        profilesList.layoutManager = lm
+        profilesList.itemAnimator = DefaultItemAnimator()
+        profilesList.adapter = profilesAdapter
+        if (DataStore.udpFallback != null)
+            lm.scrollToPosition(profilesAdapter.profiles.indexOfFirst { it.id == DataStore.udpFallback } + 1)
+    }
+}

--- a/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
@@ -44,7 +44,6 @@ import com.github.shadowsocks.ToolbarFragment
 import com.github.shadowsocks.bg.BaseService
 import com.github.shadowsocks.utils.Subnet
 import com.github.shadowsocks.utils.asIterable
-import com.github.shadowsocks.utils.printLog
 import com.github.shadowsocks.utils.resolveResourceId
 import com.github.shadowsocks.widget.UndoSnackbarManager
 import com.google.android.material.textfield.TextInputLayout
@@ -339,7 +338,7 @@ class CustomRulesFragment : ToolbarFragment(), Toolbar.OnMenuItemClickListener, 
     }
 
     private val isEnabled get() = when ((activity as MainActivity).state) {
-        BaseService.CONNECTED -> Core.currentProfile?.route != Acl.CUSTOM_RULES
+        BaseService.CONNECTED -> Core.currentProfile?.first?.route != Acl.CUSTOM_RULES
         BaseService.STOPPED -> true
         else -> false
     }

--- a/mobile/src/main/java/com/github/shadowsocks/bg/TileService.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/bg/TileService.kt
@@ -31,6 +31,7 @@ import com.github.shadowsocks.R
 import com.github.shadowsocks.ShadowsocksConnection
 import com.github.shadowsocks.aidl.IShadowsocksService
 import com.github.shadowsocks.aidl.IShadowsocksServiceCallback
+import com.github.shadowsocks.aidl.TrafficStats
 import com.github.shadowsocks.preference.DataStore
 
 @RequiresApi(24)
@@ -65,7 +66,7 @@ class TileService : BaseTileService(), ShadowsocksConnection.Interface {
                 tile.label = label ?: getString(R.string.app_name)
                 tile.updateTile()
             }
-            override fun trafficUpdated(profileId: Long, txRate: Long, rxRate: Long, txTotal: Long, rxTotal: Long) { }
+            override fun trafficUpdated(profileId: Long, stats: TrafficStats) { }
             override fun trafficPersisted(profileId: Long) { }
         }
     }

--- a/mobile/src/main/res/layout/layout_udp_fallback.xml
+++ b/mobile/src/main/res/layout/layout_udp_fallback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+    <include layout="@layout/toolbar_light_dark" />
+    <androidx.recyclerview.widget.RecyclerView android:id="@+id/list"
+                                               android:layout_width="match_parent"
+                                               android:layout_height="match_parent"
+                                               tools:itemview="@android:layout/select_dialog_singlechoice_material"
+                                               android:scrollbars="vertical"/>
+</LinearLayout>

--- a/mobile/src/main/res/xml/pref_profile.xml
+++ b/mobile/src/main/res/xml/pref_profile.xml
@@ -86,6 +86,13 @@
                 android:persistent="false"
                 app:pref_summaryHasText="%s"
                 android:title="@string/plugin_configure"/>
+        <Preference
+                android:key="udpFallback"
+                android:title="@string/udp_fallback"
+                android:summary="@string/plugin_disabled">
+            <intent android:targetPackage="com.github.shadowsocks"
+                    android:targetClass="com.github.shadowsocks.UdpFallbackProfileActivity"/>
+        </Preference>
 
     </PreferenceCategory>
 

--- a/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
+++ b/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
@@ -45,6 +45,7 @@ import com.github.shadowsocks.Core
 import com.github.shadowsocks.ShadowsocksConnection
 import com.github.shadowsocks.aidl.IShadowsocksService
 import com.github.shadowsocks.aidl.IShadowsocksServiceCallback
+import com.github.shadowsocks.aidl.TrafficStats
 import com.github.shadowsocks.bg.BaseService
 import com.github.shadowsocks.bg.Executable
 import com.github.shadowsocks.database.Profile
@@ -93,11 +94,12 @@ class MainPreferenceFragment : LeanbackPreferenceFragment(), ShadowsocksConnecti
             override fun stateChanged(state: Int, profileName: String?, msg: String?) {
                 Core.handler.post { changeState(state, msg) }
             }
-            override fun trafficUpdated(profileId: Long, txRate: Long, rxRate: Long, txTotal: Long, rxTotal: Long) {
-                stats.summary = getString(R.string.stat_summary,
-                        getString(R.string.speed, Formatter.formatFileSize(activity, txRate)),
-                        getString(R.string.speed, Formatter.formatFileSize(activity, rxRate)),
-                        Formatter.formatFileSize(activity, txTotal), Formatter.formatFileSize(activity, rxTotal))
+            override fun trafficUpdated(profileId: Long, stats: TrafficStats) {
+                if (profileId == 0L) this@MainPreferenceFragment.stats.summary = getString(R.string.stat_summary,
+                        getString(R.string.speed, Formatter.formatFileSize(activity, stats.txRate)),
+                        getString(R.string.speed, Formatter.formatFileSize(activity, stats.rxRate)),
+                        Formatter.formatFileSize(activity, stats.txTotal),
+                        Formatter.formatFileSize(activity, stats.rxTotal))
             }
             override fun trafficPersisted(profileId: Long) { }
         }
@@ -115,7 +117,7 @@ class MainPreferenceFragment : LeanbackPreferenceFragment(), ShadowsocksConnecti
         stats.isVisible = state == BaseService.CONNECTED
         val owner = activity as FragmentActivity    // TODO: change to this when refactored to androidx
         if (state != BaseService.CONNECTED) {
-            serviceCallback.trafficUpdated(0, 0, 0, 0, 0)
+            serviceCallback.trafficUpdated(0, TrafficStats())
             tester.status.removeObservers(owner)
             if (state != BaseService.IDLE) tester.invalidate()
         } else tester.status.observe(owner, Observer {
@@ -300,7 +302,7 @@ class MainPreferenceFragment : LeanbackPreferenceFragment(), ShadowsocksConnecti
                 ProfileManager.clear()
                 for (uri in data!!.datas) try {
                     Profile.parseJson(activity.contentResolver.openInputStream(uri)!!.bufferedReader().readText(),
-                            feature).forEach {
+                            feature) {
                         // if two profiles has the same address, treat them as the same profile and copy stats over
                         profiles?.get(it.formattedAddress)?.apply {
                             it.tx = tx
@@ -318,8 +320,9 @@ class MainPreferenceFragment : LeanbackPreferenceFragment(), ShadowsocksConnecti
                 if (resultCode != Activity.RESULT_OK) return
                 val profiles = ProfileManager.getAllProfiles()
                 if (profiles != null) try {
+                    val lookup = profiles.associateBy { it.id }
                     activity.contentResolver.openOutputStream(data?.data!!)!!.bufferedWriter().use {
-                        it.write(JSONArray(profiles.map { it.toJson() }.toTypedArray()).toString(2))
+                        it.write(JSONArray(profiles.map { it.toJson(lookup) }.toTypedArray()).toString(2))
                     }
                 } catch (e: Exception) {
                     printLog(e)


### PR DESCRIPTION
When a profile is selected as UDP fallback, only its server settings are respected. Tested with core.androidTest and locally with QUIC in YouTube app with plugin enabled. UDP fallback can also be used with a profile without any plugin used. (just because it's possible)

Other notable changes:

* `IShadowsocksServiceCallback.trafficUpdated` now gets an object/data class for 4 stats. When profileId = 0, stats object represents the accumulated stats for all profiles.
* Refactor `TrafficMonitor`.
* Importing/exporting via JSON using a new field `udp_fallback`.
* PrivateDatabase is updated to version 27 to accommodate the new field.

Fix #2064. Might need more testing.