### PR TITLE
Plugin library 1.1.0

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/ProfileConfigFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/ProfileConfigFragment.kt
@@ -149,7 +149,7 @@ class ProfileConfigFragment : PreferenceFragmentCompat(),
         DataStore.plugin = pluginConfiguration.toString()
         DataStore.dirty = true
         true
-    } catch (exc: IllegalArgumentException) {
+    } catch (exc: RuntimeException) {
         (activity as MainActivity).snackbar(exc.localizedMessage).show()
         false
     }

--- a/mobile/src/main/res/xml/pref_profile.xml
+++ b/mobile/src/main/res/xml/pref_profile.xml
@@ -84,6 +84,7 @@
                 android:key="plugin.configure"
                 android:icon="@drawable/ic_action_settings"
                 android:persistent="false"
+                android:singleLine="true"
                 app:pref_summaryHasText="%s"
                 android:title="@string/plugin_configure"/>
         <Preference

--- a/plugin/CHANGES.md
+++ b/plugin/CHANGES.md
@@ -1,4 +1,6 @@
 * 1.1.0:
+  * Having control characters in plugin options is no longer allowed.
+    If this breaks your plugin, you are doing it wrong.
   * New helper method: `PluginOptions.putWithDefault`.
 * 1.0.0:
   * `PathProvider` now takes `Int` instead of `String` for file modes;

--- a/plugin/CHANGES.md
+++ b/plugin/CHANGES.md
@@ -1,3 +1,4 @@
+* 1.1.0:
 * 1.0.0:
   * `PathProvider` now takes `Int` instead of `String` for file modes;
   * Refactor to AndroidX;

--- a/plugin/CHANGES.md
+++ b/plugin/CHANGES.md
@@ -1,4 +1,5 @@
 * 1.1.0:
+  * New helper method: `PluginOptions.putWithDefault`.
 * 1.0.0:
   * `PathProvider` now takes `Int` instead of `String` for file modes;
   * Refactor to AndroidX;

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.sdkVersion
-        versionCode 7
-        versionName "1.0.0"
+        versionCode 8
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/plugin/src/main/java/com/github/shadowsocks/plugin/PluginOptions.kt
+++ b/plugin/src/main/java/com/github/shadowsocks/plugin/PluginOptions.kt
@@ -38,6 +38,7 @@ class PluginOptions : HashMap<String, String?> {
         @Suppress("NAME_SHADOWING")
         var parseId = parseId
         if (options.isNullOrEmpty()) return
+        check(options.all { !it.isISOControl() }) { "No control characters allowed." }
         val tokenizer = StringTokenizer("$options;", "\\=;", true)
         val current = StringBuilder()
         var key: String? = null

--- a/plugin/src/main/java/com/github/shadowsocks/plugin/PluginOptions.kt
+++ b/plugin/src/main/java/com/github/shadowsocks/plugin/PluginOptions.kt
@@ -68,6 +68,14 @@ class PluginOptions : HashMap<String, String?> {
         this.id = id
     }
 
+    /**
+     * Put but if value is null or default, the entry is deleted.
+     *
+     * @return Old value before put.
+     */
+    fun putWithDefault(key: String, value: String?, default: String? = null) =
+            if (value == null || value == default) remove(key) else put(key, value)
+
     private fun append(result: StringBuilder, str: String) = (0 until str.length)
             .map { str[it] }
             .forEach {

--- a/plugin/src/test/java/com/github/shadowsocks/plugin/PluginOptionsTest.kt
+++ b/plugin/src/test/java/com/github/shadowsocks/plugin/PluginOptionsTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 
 class PluginOptionsTest {
     @Test
-    fun equal() {
+    fun basic() {
         val o1 = PluginOptions("obfs-local;obfs=http;obfs-host=localhost")
         val o2 = PluginOptions("obfs-local", "obfs-host=localhost;obfs=http")
         Assert.assertEquals(o1.hashCode(), o2.hashCode())
@@ -34,5 +34,20 @@ class PluginOptionsTest {
         Assert.assertEquals(true, o2 == o3)
         val o4 = PluginOptions(o2.id, o2.toString())
         Assert.assertEquals(true, o3 == o4)
+    }
+
+    @Test
+    fun escape() {
+        val options = PluginOptions("escapeTest")
+        options["subject"] = "value;semicolon"
+        Assert.assertEquals(true, options == PluginOptions(options.toString(false)))
+        options["key;semicolon"] = "object"
+        Assert.assertEquals(true, options == PluginOptions(options.toString(false)))
+        options["subject"] = "value=equals"
+        Assert.assertEquals(true, options == PluginOptions(options.toString(false)))
+        options["key=equals"] = "object"
+        Assert.assertEquals(true, options == PluginOptions(options.toString(false)))
+        options["advanced\\=;test"] = "in;=\\progress"
+        Assert.assertEquals(true, options == PluginOptions(options.toString(false)))
     }
 }


### PR DESCRIPTION
Okay. Our old `beta`/`develop` branches definitely went nowhere. Let's just replace `beta` with feature PRs and `develop` with PRs like this one. In theory we should release an update for plugin lib immediately after merging PRs like this one.