### PR TITLE
Add links to Google Play beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-orange.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 <a href="https://play.google.com/store/apps/details?id=com.github.shadowsocks"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="48"></a>
-for Android & Chrome OS  
+for Android & Chrome OS ([beta](https://play.google.com/apps/testing/com.github.shadowsocks))  
 <a href="https://play.google.com/store/apps/details?id=com.github.shadowsocks.tv"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="48"></a>
-for Android TV
+for Android TV ([beta](https://play.google.com/apps/testing/com.github.shadowsocks.tv))
 
 
 ### PREREQUISITES


### PR DESCRIPTION
Google Play Store on TV does not offer the option to opt in to beta AFAIC. It might be a good idea to put a link somewhere.