### PR TITLE
Refactor using coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
     ext {
         kotlinVersion = '1.3.20'
-        kotlinCoroutinesVersion = '1.1.0'
         minSdkVersion = 21
         sdkVersion = 28
         compileSdkVersion = 28

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
     ext {
         kotlinVersion = '1.3.11'
+        kotlinCoroutinesVersion = '1.1.0'
         minSdkVersion = 21
         sdkVersion = 28
         compileSdkVersion = 28

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
     ext {
-        kotlinVersion = '1.3.11'
+        kotlinVersion = '1.3.20'
         kotlinCoroutinesVersion = '1.1.0'
         minSdkVersion = 21
         sdkVersion = 28

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,13 +62,15 @@ dependencies {
     api "android.arch.work:work-runtime-ktx:$workVersion"
     api "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
-    api "androidx.preference:preference:1.0.0"
+    api 'androidx.preference:preference:1.0.0'
     api "androidx.room:room-runtime:$roomVersion"
     api 'com.crashlytics.sdk.android:crashlytics:2.9.8'
     api 'com.google.firebase:firebase-config:16.1.3'
     api 'com.google.firebase:firebase-core:16.0.6'
     api 'com.squareup.okhttp3:okhttp:3.12.1'
     api "com.takisoft.preferencex:preferencex:$preferencexVersion"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     testImplementation "androidx.arch.core:core-testing:$lifecycleVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     api 'com.crashlytics.sdk.android:crashlytics:2.9.8'
     api 'com.google.firebase:firebase-config:16.1.3'
     api 'com.google.firebase:firebase-core:16.0.6'
-    api 'com.squareup.okhttp3:okhttp:3.12.1'
     api "com.takisoft.preferencex:preferencex:$preferencexVersion"
     api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0'
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,8 +69,7 @@ dependencies {
     api 'com.google.firebase:firebase-core:16.0.6'
     api 'com.squareup.okhttp3:okhttp:3.12.1'
     api "com.takisoft.preferencex:preferencex:$preferencexVersion"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0'
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     testImplementation "androidx.arch.core:core-testing:$lifecycleVersion"

--- a/core/src/main/java/com/github/shadowsocks/Core.kt
+++ b/core/src/main/java/com/github/shadowsocks/Core.kt
@@ -51,6 +51,8 @@ import com.github.shadowsocks.utils.*
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import io.fabric.sdk.android.Fabric
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.io.File
 import java.io.IOException
 import kotlin.reflect.KClass
@@ -106,7 +108,7 @@ object Core {
         // handle data restored/crash
         if (Build.VERSION.SDK_INT >= 24 && DataStore.directBootAware &&
                 app.getSystemService<UserManager>()?.isUserUnlocked == true) DirectBoot.flushTrafficStats()
-        if (DataStore.tcpFastOpen && !TcpFastOpen.sendEnabled) TcpFastOpen.enableAsync()
+        if (DataStore.tcpFastOpen && !TcpFastOpen.sendEnabled) TcpFastOpen.enableTimeout()
         if (DataStore.publicStore.getLong(Key.assetUpdateTime, -1) != packageInfo.lastUpdateTime) {
             val assetManager = app.assets
             for (dir in arrayOf("acl", "overture"))

--- a/core/src/main/java/com/github/shadowsocks/Core.kt
+++ b/core/src/main/java/com/github/shadowsocks/Core.kt
@@ -32,8 +32,6 @@ import android.content.IntentFilter
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.os.UserManager
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -51,8 +49,6 @@ import com.github.shadowsocks.utils.*
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import io.fabric.sdk.android.Fabric
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import java.io.File
 import java.io.IOException
 import kotlin.reflect.KClass
@@ -62,7 +58,6 @@ object Core {
 
     lateinit var app: Application
     lateinit var configureIntent: (Context) -> PendingIntent
-    val handler by lazy { Handler(Looper.getMainLooper()) }
     val packageInfo: PackageInfo by lazy { getPackageInfo(app.packageName) }
     val deviceStorage by lazy { if (Build.VERSION.SDK_INT < 24) app else DeviceStorageApp(app) }
     val analytics: FirebaseAnalytics by lazy { FirebaseAnalytics.getInstance(deviceStorage) }

--- a/core/src/main/java/com/github/shadowsocks/bg/GuardedProcessPool.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/GuardedProcessPool.kt
@@ -26,135 +26,104 @@ import android.system.ErrnoException
 import android.system.Os
 import android.system.OsConstants
 import android.util.Log
+import androidx.annotation.MainThread
 import com.crashlytics.android.Crashlytics
 import com.github.shadowsocks.Core
 import com.github.shadowsocks.utils.Commandline
-import com.github.shadowsocks.utils.thread
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.select
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
-class GuardedProcessPool {
-    companion object Dummy : IOException("Oopsie the developer has made a no-no") {
+class GuardedProcessPool : CoroutineScope {
+    companion object {
         private const val TAG = "GuardedProcessPool"
-        private val ProcessImpl by lazy { Class.forName("java.lang.ProcessManager\$ProcessImpl") }
-        private val pid by lazy { ProcessImpl.getDeclaredField("pid").apply { isAccessible = true } }
-        private val exitValueMutex by lazy {
-            ProcessImpl.getDeclaredField("exitValueMutex").apply { isAccessible = true }
+        private val pid by lazy {
+            Class.forName("java.lang.ProcessManager\$ProcessImpl").getDeclaredField("pid").apply { isAccessible = true }
         }
     }
 
-    private inner class Guard(private val cmd: List<String>, private val onRestartCallback: (() -> Unit)?) {
-        val cmdName = File(cmd.first()).nameWithoutExtension
-        val excQueue = ArrayBlockingQueue<IOException>(1)   // ArrayBlockingQueue doesn't want null
-        private var pushed = false
+    private inner class Guard(private val cmd: List<String>) {
+        val abortChannel = Channel<Unit>()
+        private val exitChannel = Channel<Int>()
+        private val cmdName = File(cmd.first()).nameWithoutExtension
+        private var startTime: Long = -1
+        private lateinit var process: Process
 
-        private fun streamLogger(input: InputStream, logger: (String, String) -> Int) =
-                thread("StreamLogger-$cmdName") {
-                    try {
-                        input.bufferedReader().forEachLine { logger(TAG, it) }
-                    } catch (_: IOException) { }    // ignore
-                }
-        private fun pushException(ioException: IOException?) {
-            if (pushed) return
-            excQueue.put(ioException ?: Dummy)
-            pushed = true
+        private fun streamLogger(input: InputStream, logger: (String, String) -> Int) = try {
+            input.bufferedReader().forEachLine { logger(TAG, it) }
+        } catch (_: IOException) { }    // ignore
+
+        fun start() {
+            startTime = SystemClock.elapsedRealtime()
+            process = ProcessBuilder(cmd).directory(Core.deviceStorage.noBackupFilesDir).start()
         }
 
-        fun looper(host: HashSet<Thread>) {
-            var process: Process? = null
+        suspend fun looper(onRestartCallback: (() -> Unit)?) {
+            var running = true
             try {
-                var callback: (() -> Unit)? = null
-                while (guardThreads.get() === host) {
-                    Crashlytics.log(Log.DEBUG, TAG, "start process: " + Commandline.toString(cmd))
-                    val startTime = SystemClock.elapsedRealtime()
-
-                    process = ProcessBuilder(cmd)
-                            .redirectErrorStream(true)
-                            .directory(Core.deviceStorage.noBackupFilesDir)
-                            .start()
-
-                    streamLogger(process.inputStream, Log::i)
-                    streamLogger(process.errorStream, Log::e)
-
-                    if (callback == null) callback = onRestartCallback else callback()
-
-                    pushException(null)
-                    process.waitFor()
-
+                while (true) {
+                    thread(name = "stderr-$cmdName") { streamLogger(process.errorStream, Log::e) }
+                    thread(name = "stdout-$cmdName") {
+                        runBlocking {
+                            streamLogger(process.inputStream, Log::i)
+                            exitChannel.send(process.waitFor()) // this thread also acts as a daemon thread for waitFor
+                        }
+                    }
+                    if (select {
+                                abortChannel.onReceive { true } // prefer abort to save work
+                                exitChannel.onReceive { false }
+                            }) break
+                    running = false
                     if (SystemClock.elapsedRealtime() - startTime < 1000) {
                         Crashlytics.log(Log.WARN, TAG, "process exit too fast, stop guard: $cmdName")
                         break
                     }
+                    Crashlytics.log(Log.DEBUG, TAG, "restart process: " + Commandline.toString(cmd))
+                    start()
+                    running = true
+                    onRestartCallback?.invoke()
                 }
-            } catch (_: InterruptedException) {
-                Crashlytics.log(Log.DEBUG, TAG, "thread interrupt, destroy process: $cmdName")
-            } catch (e: IOException) {
-                pushException(e)
             } finally {
-                if (process != null) {
-                    if (Build.VERSION.SDK_INT < 24) {
-                        val pid = pid.get(process) as Int
-                        try {
-                            Os.kill(pid, OsConstants.SIGTERM)
-                        } catch (e: ErrnoException) {
-                            if (e.errno != OsConstants.ESRCH) throw e
-                        }
-                        val mutex = exitValueMutex.get(process) as Object
-                        synchronized(mutex) {
-                            try {
-                                process.exitValue()
-                            } catch (e: IllegalThreadStateException) {
-                                mutex.wait(500)
-                            }
-                        }
+                if (!running) return    // process already exited, nothing to be done
+                if (Build.VERSION.SDK_INT < 24) {
+                    val pid = pid.get(process) as Int
+                    try {
+                        Os.kill(pid, OsConstants.SIGTERM)
+                    } catch (e: ErrnoException) {
+                        if (e.errno != OsConstants.ESRCH) throw e
                     }
-
-                    process.destroy() // kill the process
-
-                    if (Build.VERSION.SDK_INT >= 26) {
-                        val isKilled = process.waitFor(1L, TimeUnit.SECONDS) // wait for 1 second
-                        if (!isKilled) {
-                            process.destroyForcibly() // Force to kill the process if it's still alive
-                        }
-                    }
-
-                    process.waitFor()   // ensure the process is destroyed
+                    if (withTimeoutOrNull(500) { exitChannel.receive() } != null) return
                 }
-                pushException(null)
+                process.destroy() // kill the process
+                if (Build.VERSION.SDK_INT >= 26) {
+                    if (withTimeoutOrNull(1000) { exitChannel.receive() } != null) return
+                    process.destroyForcibly() // Force to kill the process if it's still alive
+                }
+                exitChannel.receive()
             }
         }
     }
 
-    /**
-     * This is an indication of which thread pool is being active.
-     * Reading/writing this collection still needs an additional lock to prevent concurrent modification.
-     */
-    private val guardThreads = AtomicReference<HashSet<Thread>>(HashSet())
+    private val supervisor = SupervisorJob()
+    override val coroutineContext get() = Dispatchers.Main + supervisor
+    private val guards = ArrayList<Guard>()
 
-    fun start(cmd: List<String>, onRestartCallback: (() -> Unit)? = null): GuardedProcessPool {
-        val guard = Guard(cmd, onRestartCallback)
-        val guardThreads = guardThreads.get()
-        synchronized(guardThreads) {
-            guardThreads.add(thread("GuardThread-${guard.cmdName}") {
-                guard.looper(guardThreads)
-            })
-        }
-        val ioException = guard.excQueue.take()
-        if (ioException !== Dummy) throw ioException
-        return this
+    @MainThread
+    suspend fun start(cmd: List<String>, onRestartCallback: (() -> Unit)? = null) {
+        Crashlytics.log(Log.DEBUG, TAG, "start process: " + Commandline.toString(cmd))
+        val guard = Guard(cmd)
+        guard.start()
+        guards += guard
+        launch(start = CoroutineStart.UNDISPATCHED) { guard.looper(onRestartCallback) }
     }
 
-    fun killAll() {
-        val guardThreads = guardThreads.getAndSet(HashSet())
-        synchronized(guardThreads) {
-            guardThreads.forEach { it.interrupt() }
-            try {
-                guardThreads.forEach { it.join() }
-            } catch (_: InterruptedException) { }
-        }
+    @MainThread
+    suspend fun close() {
+        guards.forEach { it.abortChannel.send(Unit) }
+        supervisor.children.forEach { it.join() }
     }
 }

--- a/core/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/LocalDnsService.kt
@@ -32,8 +32,8 @@ import org.json.JSONObject
 
 object LocalDnsService {
     interface Interface : BaseService.Interface {
-        override fun startNativeProcesses() {
-            super.startNativeProcesses()
+        override suspend fun startProcesses() {
+            super.startProcesses()
             val data = data
             val profile = data.proxy!!.profile
 
@@ -86,7 +86,7 @@ object LocalDnsService {
                 })
             }
 
-            if (!profile.udpdns) data.processes.start(buildAdditionalArguments(arrayListOf(
+            if (!profile.udpdns) data.processes!!.start(buildAdditionalArguments(arrayListOf(
                     File(app.applicationInfo.nativeLibraryDir, Executable.OVERTURE).absolutePath,
                     "-c", buildOvertureConfig("overture.conf"))))
         }

--- a/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
@@ -23,6 +23,7 @@ package com.github.shadowsocks.bg
 import android.net.LocalServerSocket
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
+import android.system.ErrnoException
 import android.system.Os
 import android.system.OsConstants
 import com.github.shadowsocks.utils.printLog
@@ -56,7 +57,11 @@ abstract class LocalSocketListener(name: String, socketFile: File) : Thread(name
     override fun close() {
         running = false
         // see also: https://issuetracker.google.com/issues/36945762#comment15
-        Os.shutdown(localSocket.fileDescriptor, OsConstants.SHUT_RDWR)
+        try {
+            Os.shutdown(localSocket.fileDescriptor, OsConstants.SHUT_RDWR)
+        } catch (e: ErrnoException) {
+            if (e.errno != OsConstants.EBADF) throw e   // suppress fd already closed
+        }
         join()
     }
 }

--- a/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
@@ -23,16 +23,18 @@ package com.github.shadowsocks.bg
 import android.net.LocalServerSocket
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
+import android.system.Os
+import android.system.OsConstants
 import com.github.shadowsocks.utils.printLog
 import java.io.File
 import java.io.IOException
 
-abstract class LocalSocketListener(protected val tag: String) : Thread(tag) {
-    init {
-        setUncaughtExceptionHandler { _, t -> printLog(t) }
+abstract class LocalSocketListener(name: String, socketFile: File) : Thread(name), AutoCloseable {
+    private val localSocket = LocalSocket().apply {
+        socketFile.delete() // It's a must-have to close and reuse previous local socket.
+        bind(LocalSocketAddress(socketFile.absolutePath, LocalSocketAddress.Namespace.FILESYSTEM))
     }
-
-    protected abstract val socketFile: File
+    private val serverSocket = LocalServerSocket(localSocket.fileDescriptor)
     @Volatile
     private var running = true
 
@@ -40,29 +42,21 @@ abstract class LocalSocketListener(protected val tag: String) : Thread(tag) {
      * Inherited class do not need to close input/output streams as they will be closed automatically.
      */
     protected abstract fun accept(socket: LocalSocket)
-    final override fun run() {
-        socketFile.delete() // It's a must-have to close and reuse previous local socket.
-        LocalSocket().use { localSocket ->
-            val serverSocket = try {
-                localSocket.bind(LocalSocketAddress(socketFile.absolutePath, LocalSocketAddress.Namespace.FILESYSTEM))
-                LocalServerSocket(localSocket.fileDescriptor)
+    final override fun run() = localSocket.use {
+        while (running) {
+            try {
+                serverSocket.accept().use { accept(it) }
             } catch (e: IOException) {
-                printLog(e)
-                return
-            }
-            while (running) {
-                try {
-                    serverSocket.accept()
-                } catch (e: IOException) {
-                    printLog(e)
-                    continue
-                }?.use(this::accept)
+                if (running) printLog(e)
+                continue
             }
         }
     }
 
-    fun stopThread() {
+    override fun close() {
         running = false
-        interrupt()
+        // see also: https://issuetracker.google.com/issues/36945762#comment15
+        Os.shutdown(localSocket.fileDescriptor, OsConstants.SHUT_RDWR)
+        join()
     }
 }

--- a/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/LocalSocketListener.kt
@@ -45,7 +45,7 @@ abstract class LocalSocketListener(name: String, socketFile: File) : Thread(name
     final override fun run() = localSocket.use {
         while (running) {
             try {
-                serverSocket.accept().use { accept(it) }
+                accept(serverSocket.accept())
             } catch (e: IOException) {
                 if (running) printLog(e)
                 continue

--- a/core/src/main/java/com/github/shadowsocks/bg/RemoteConfig.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/RemoteConfig.kt
@@ -25,11 +25,12 @@ import androidx.core.os.bundleOf
 import com.github.shadowsocks.Core
 import com.github.shadowsocks.core.R
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import java.net.URL
 
 object RemoteConfig {
     private val config = FirebaseRemoteConfig.getInstance().apply { setDefaults(R.xml.default_configs) }
 
-    val proxyUrl get() = config.getString("proxy_url")
+    val proxyUrl get() = URL(config.getString("proxy_url"))
 
     fun fetch() = config.fetch().addOnCompleteListener {
         if (it.isSuccessful) config.activateFetched() else {

--- a/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
@@ -30,7 +30,7 @@ import java.nio.ByteOrder
 
 class TrafficMonitor(statFile: File) : AutoCloseable {
     private val thread = object : LocalSocketListener("TrafficMonitor", statFile) {
-        override fun accept(socket: LocalSocket) {
+        override fun accept(socket: LocalSocket) = socket.use {
             val buffer = ByteArray(16)
             if (socket.inputStream.read(buffer) != 16) throw IOException("Unexpected traffic stat length")
             val stat = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN)

--- a/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
@@ -23,33 +23,26 @@ package com.github.shadowsocks.bg
 import android.net.LocalSocket
 import android.os.SystemClock
 import com.github.shadowsocks.aidl.TrafficStats
-import com.github.shadowsocks.utils.printLog
 import java.io.File
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 class TrafficMonitor(statFile: File) : AutoCloseable {
-    private val thread = object : LocalSocketListener("TrafficMonitor") {
-        override val socketFile = statFile
-
+    private val thread = object : LocalSocketListener("TrafficMonitor", statFile) {
         override fun accept(socket: LocalSocket) {
-            try {
-                val buffer = ByteArray(16)
-                if (socket.inputStream.read(buffer) != 16) throw IOException("Unexpected traffic stat length")
-                val stat = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN)
-                val tx = stat.getLong(0)
-                val rx = stat.getLong(8)
-                if (current.txTotal != tx) {
-                    current.txTotal = tx
-                    dirty = true
-                }
-                if (current.rxTotal != rx) {
-                    current.rxTotal = rx
-                    dirty = true
-                }
-            } catch (e: IOException) {
-                printLog(e)
+            val buffer = ByteArray(16)
+            if (socket.inputStream.read(buffer) != 16) throw IOException("Unexpected traffic stat length")
+            val stat = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN)
+            val tx = stat.getLong(0)
+            val rx = stat.getLong(8)
+            if (current.txTotal != tx) {
+                current.txTotal = tx
+                dirty = true
+            }
+            if (current.rxTotal != rx) {
+                current.rxTotal = rx
+                dirty = true
             }
         }
     }.apply { start() }
@@ -57,7 +50,6 @@ class TrafficMonitor(statFile: File) : AutoCloseable {
     val current = TrafficStats()
     var out = TrafficStats()
     private var timestampLast = 0L
-    @Volatile
     private var dirty = false
 
     fun requestUpdate(): Pair<TrafficStats, Boolean> {
@@ -87,5 +79,5 @@ class TrafficMonitor(statFile: File) : AutoCloseable {
         return Pair(out, updated)
     }
 
-    override fun close() = thread.stopThread()
+    override fun close() = thread.close()
 }

--- a/core/src/main/java/com/github/shadowsocks/utils/TcpFastOpen.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/TcpFastOpen.kt
@@ -20,6 +20,8 @@
 
 package com.github.shadowsocks.utils
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.io.IOException
 
@@ -58,5 +60,5 @@ object TcpFastOpen {
             e.localizedMessage
         }
     }
-    fun enableAsync() = thread("TcpFastOpen") { enable() }.join(1000)
+    fun enableTimeout() = runBlocking { withTimeoutOrNull(1000) { enable() } }
 }

--- a/core/src/main/java/com/github/shadowsocks/utils/Utils.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/Utils.kt
@@ -54,17 +54,6 @@ fun broadcastReceiver(callback: (Context, Intent) -> Unit): BroadcastReceiver = 
     override fun onReceive(context: Context, intent: Intent) = callback(context, intent)
 }
 
-/**
- * Wrapper for kotlin.concurrent.thread that tracks uncaught exceptions.
- */
-fun thread(name: String? = null, start: Boolean = true, isDaemon: Boolean = false,
-           contextClassLoader: ClassLoader? = null, priority: Int = -1, block: () -> Unit): Thread {
-    val thread = kotlin.concurrent.thread(false, isDaemon, contextClassLoader, name, priority, block)
-    thread.setUncaughtExceptionHandler { _, t -> printLog(t) }
-    if (start) thread.start()
-    return thread
-}
-
 val URLConnection.responseLength: Long
     get() = if (Build.VERSION.SDK_INT >= 24) contentLengthLong else contentLength.toLong()
 

--- a/mobile/proguard-rules.pro
+++ b/mobile/proguard-rules.pro
@@ -22,5 +22,3 @@
 #-renamesourcefileattribute SourceFile
 
 -dontwarn com.google.android.gms.internal.**
--dontwarn okhttp3.**
--dontwarn okio.**

--- a/mobile/src/main/res/layout/layout_apps.xml
+++ b/mobile/src/main/res/layout/layout_apps.xml
@@ -55,11 +55,13 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:id="@+id/list"
+            android:visibility="gone"
             app:fastScrollEnabled="true"
             app:fastScrollHorizontalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollHorizontalTrackDrawable="@drawable/fastscroll_line"
             app:fastScrollVerticalThumbDrawable="@drawable/fastscroll_thumb"
             app:fastScrollVerticalTrackDrawable="@drawable/fastscroll_line"
-            tools:listitem="@layout/layout_apps_item"/>
+            tools:listitem="@layout/layout_apps_item"
+            tools:visibility="visible"/>
   </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/tv/proguard-rules.pro
+++ b/tv/proguard-rules.pro
@@ -22,5 +22,3 @@
 #-renamesourcefileattribute SourceFile
 
 -dontwarn com.google.android.gms.internal.**
--dontwarn okhttp3.**
--dontwarn okio.**


### PR DESCRIPTION
What are coroutines: Basically threads but much more light-weight. `Dispatchers.Main` is implemented using Android's `Handler/Looper` mechanism.

With this PR, most bg work can be done on the main thread, so we have fewer concurrency issues to worry about. Furthermore, sockets are now protected in parallel using IO thread pool and error callbacks are refined. (see commit logs for more info)

This PR also cleans up various IO threads that live longer than that they are supposed to live. Fewer threads = less RAM!

One downside of using coroutines, however, is that debugging deadlocks can be much harder, as dumping stacks aren't useful. This might be mitigated using [kotlinx-coroutines-debug](https://github.com/Kotlin/kotlinx.coroutines/tree/master/core/kotlinx-coroutines-debug) but that needs more investigation.

This PR might help with #2083.

I don't think this will impact binary size that much as `android.arch.work:work-runtime-ktx` already uses Kotlin coroutines.