### PR TITLE
Use dnsproxyd for DNS resolving

### DIFF
--- a/core/src/androidTest/java/com/github/shadowsocks/net/SubnetTest.kt
+++ b/core/src/androidTest/java/com/github/shadowsocks/net/SubnetTest.kt
@@ -1,8 +1,8 @@
-package com.github.shadowsocks.utils
+package com.github.shadowsocks.net
 
-import java.net.InetAddress
 import org.junit.Assert
 import org.junit.Test
+import java.net.InetAddress
 
 class SubnetTest {
     @Test

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <!-- This permission is only used on Android 6.0 due to bug: https://stackoverflow.com/a/33509180/2245107 -->
+    <uses-permission-sdk-23 android:name="android.permission.WRITE_SETTINGS"/>
 
     <uses-feature android:name="android.software.leanback"
                   android:required="false"/>

--- a/core/src/main/java/com/github/shadowsocks/Core.kt
+++ b/core/src/main/java/com/github/shadowsocks/Core.kt
@@ -44,6 +44,7 @@ import com.github.shadowsocks.aidl.ShadowsocksConnection
 import com.github.shadowsocks.core.R
 import com.github.shadowsocks.database.Profile
 import com.github.shadowsocks.database.ProfileManager
+import com.github.shadowsocks.net.TcpFastOpen
 import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.*
 import com.google.firebase.FirebaseApp

--- a/core/src/main/java/com/github/shadowsocks/acl/Acl.kt
+++ b/core/src/main/java/com/github/shadowsocks/acl/Acl.kt
@@ -25,8 +25,8 @@ import android.util.Log
 import androidx.recyclerview.widget.SortedList
 import com.crashlytics.android.Crashlytics
 import com.github.shadowsocks.Core
+import com.github.shadowsocks.net.Subnet
 import com.github.shadowsocks.preference.DataStore
-import com.github.shadowsocks.utils.Subnet
 import com.github.shadowsocks.utils.asIterable
 import java.io.File
 import java.io.IOException

--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -42,6 +42,7 @@ import com.github.shadowsocks.utils.printLog
 import com.google.firebase.analytics.FirebaseAnalytics
 import kotlinx.coroutines.*
 import java.io.File
+import java.net.InetAddress
 import java.net.UnknownHostException
 import java.util.*
 
@@ -274,6 +275,9 @@ object BaseService {
             }
         }
 
+        suspend fun preInit() { }
+        suspend fun resolver(host: String) = InetAddress.getByName(host)
+
         fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
             val data = data
             if (data.state != STOPPED) return Service.START_NOT_STICKY
@@ -306,8 +310,9 @@ object BaseService {
             data.changeState(CONNECTING)
             data.connectingJob = GlobalScope.launch(Dispatchers.Main) {
                 try {
-                    proxy.init()
-                    data.udpFallback?.init()
+                    preInit()
+                    proxy.init(this@Interface::resolver)
+                    data.udpFallback?.init(this@Interface::resolver)
 
                     killProcesses()
                     data.processes = GuardedProcessPool {

--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -310,11 +310,11 @@ object BaseService {
             data.changeState(CONNECTING)
             data.connectingJob = GlobalScope.launch(Dispatchers.Main) {
                 try {
+                    killProcesses()
                     preInit()
                     proxy.init(this@Interface::resolver)
                     data.udpFallback?.init(this@Interface::resolver)
 
-                    killProcesses()
                     data.processes = GuardedProcessPool {
                         printLog(it)
                         data.connectingJob?.apply { runBlocking { cancelAndJoin() } }

--- a/core/src/main/java/com/github/shadowsocks/bg/DefaultNetworkListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/DefaultNetworkListener.kt
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package com.github.shadowsocks.bg
+
+import android.annotation.TargetApi
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import android.widget.Toast
+import androidx.core.content.getSystemService
+import com.crashlytics.android.Crashlytics
+import com.github.shadowsocks.Core.app
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.runBlocking
+
+object DefaultNetworkListener : CoroutineScope {
+    override val coroutineContext get() = Dispatchers.Default
+    private sealed class NetworkMessage {
+        class Start(val key: Any, val listener: (Network?) -> Unit) : NetworkMessage()
+        class Get : NetworkMessage() {
+            val response = CompletableDeferred<Network>()
+        }
+        class Stop(val key: Any) : NetworkMessage()
+
+        class Put(val network: Network) : NetworkMessage()
+        class Update(val network: Network) : NetworkMessage()
+        class Lost(val network: Network) : NetworkMessage()
+    }
+    private val networkActor = actor<NetworkMessage> {
+        val listeners = mutableMapOf<Any, (Network?) -> Unit>()
+        var network: Network? = null
+        val pendingRequests = arrayListOf<NetworkMessage.Get>()
+        for (message in channel) when (message) {
+            is NetworkMessage.Start -> {
+                if (listeners.isEmpty()) registerDefaultNetworkListener()
+                listeners[message.key] = message.listener
+                if (network != null) message.listener(network)
+            }
+            is NetworkMessage.Get -> {
+                check(listeners.isNotEmpty()) { "Getting network without any listeners is not supported" }
+                if (network == null) pendingRequests += message else message.response.complete(network)
+            }
+            is NetworkMessage.Stop -> {
+                if (!listeners.isEmpty() && // was not empty
+                        listeners.remove(message.key) != null && listeners.isEmpty()) unregisterDefaultNetworkListener()
+            }
+
+            is NetworkMessage.Put -> {
+                network = message.network
+                pendingRequests.forEach { it.response.complete(message.network) }
+                pendingRequests.clear()
+                listeners.values.forEach { it(network) }
+            }
+            is NetworkMessage.Update -> if (network == message.network) listeners.values.forEach { it(network) }
+            is NetworkMessage.Lost -> if (network == message.network) {
+                network = null
+                listeners.values.forEach { it(null) }
+            }
+        }
+    }
+
+    suspend fun start(key: Any, listener: (Network?) -> Unit) = networkActor.send(NetworkMessage.Start(key, listener))
+    suspend fun get() = NetworkMessage.Get().run {
+        networkActor.send(this)
+        response.await()
+    }
+    suspend fun stop(key: Any) = networkActor.send(NetworkMessage.Stop(key))
+
+    // NB: this runs in ConnectivityThread, and this behavior cannot be changed until API 26
+    private object Callback : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) = runBlocking { networkActor.send(NetworkMessage.Put(network)) }
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities?) {
+            // it's a good idea to refresh capabilities
+            runBlocking { networkActor.send(NetworkMessage.Update(network)) }
+        }
+        override fun onLost(network: Network) = runBlocking { networkActor.send(NetworkMessage.Lost(network)) }
+    }
+
+    private val connectivity = app.getSystemService<ConnectivityManager>()!!
+    private val defaultNetworkRequest = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
+            .build()
+    /**
+     * Unfortunately registerDefaultNetworkCallback is going to return VPN interface since Android P DP1:
+     * https://android.googlesource.com/platform/frameworks/base/+/dda156ab0c5d66ad82bdcf76cda07cbc0a9c8a2e
+     *
+     * This makes doing a requestNetwork with REQUEST necessary so that we don't get ALL possible networks that
+     * satisfies default network capabilities but only THE default network. Unfortunately, we need to have
+     * android.permission.CHANGE_NETWORK_STATE to be able to call requestNetwork.
+     *
+     * Source: https://android.googlesource.com/platform/frameworks/base/+/2df4c7d/services/core/java/com/android/server/ConnectivityService.java#887
+     */
+    private fun registerDefaultNetworkListener() {
+        if (Build.VERSION.SDK_INT in 24..27) @TargetApi(24) {
+            connectivity.registerDefaultNetworkCallback(Callback)
+        } else try {
+            // we want REQUEST here instead of LISTEN
+            connectivity.requestNetwork(defaultNetworkRequest, Callback)
+        } catch (e: SecurityException) {
+            // known bug: https://stackoverflow.com/a/33509180/2245107
+            if (Build.VERSION.SDK_INT != 23) Crashlytics.logException(e)
+            Toast.makeText(app, e.localizedMessage, Toast.LENGTH_SHORT).show()
+            connectivity.registerNetworkCallback(defaultNetworkRequest, Callback)
+        }
+    }
+    private fun unregisterDefaultNetworkListener() = connectivity.unregisterNetworkCallback(Callback)
+}

--- a/core/src/main/java/com/github/shadowsocks/bg/GuardedProcessPool.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/GuardedProcessPool.kt
@@ -116,7 +116,7 @@ class GuardedProcessPool(private val onFatal: (IOException) -> Unit) : Coroutine
     private val guards = ArrayList<Guard>()
 
     @MainThread
-    suspend fun start(cmd: List<String>, onRestartCallback: (suspend () -> Unit)? = null) {
+    fun start(cmd: List<String>, onRestartCallback: (suspend () -> Unit)? = null) {
         Crashlytics.log(Log.DEBUG, TAG, "start process: " + Commandline.toString(cmd))
         val guard = Guard(cmd)
         guard.start()

--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -92,7 +92,7 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
      * Sensitive shadowsocks configuration file requires extra protection. It may be stored in encrypted storage or
      * device storage, depending on which is currently available.
      */
-    suspend fun start(service: BaseService.Interface, stat: File, configFile: File, extraFlag: String? = null) {
+    fun start(service: BaseService.Interface, stat: File, configFile: File, extraFlag: String? = null) {
         trafficMonitor = TrafficMonitor(stat)
 
         this.configFile = configFile

--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -52,7 +52,7 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
     private val plugin = PluginConfiguration(profile.plugin ?: "").selectedOptions
     val pluginPath by lazy { PluginManager.init(plugin) }
 
-    suspend fun init() {
+    suspend fun init(resolver: suspend (String) -> InetAddress) {
         if (profile.host == "198.199.101.152") {
             val mdg = MessageDigest.getInstance("SHA-1")
             mdg.update(Core.packageInfo.signaturesCompat.first().toByteArray())
@@ -84,7 +84,7 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
 
         // it's hard to resolve DNS on a specific interface so we'll do it here
         if (profile.host.parseNumericAddress() == null) profile.host = withTimeout(10_000) {
-            withContext(Dispatchers.IO) { InetAddress.getByName(profile.host).hostAddress }
+            withContext(Dispatchers.IO) { resolver(profile.host).hostAddress }
         } ?: throw UnknownHostException()
     }
 

--- a/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
@@ -31,7 +31,7 @@ import java.nio.ByteOrder
 
 class TrafficMonitor(statFile: File) : AutoCloseable {
     private val thread = object : LocalSocketListener("TrafficMonitor", statFile) {
-        override fun accept(socket: LocalSocket) = socket.use {
+        override fun acceptInternal(socket: LocalSocket) {
             val buffer = ByteArray(16)
             if (socket.inputStream.read(buffer) != 16) throw IOException("Unexpected traffic stat length")
             val stat = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN)

--- a/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TrafficMonitor.kt
@@ -23,6 +23,7 @@ package com.github.shadowsocks.bg
 import android.net.LocalSocket
 import android.os.SystemClock
 import com.github.shadowsocks.aidl.TrafficStats
+import com.github.shadowsocks.net.LocalSocketListener
 import java.io.File
 import java.io.IOException
 import java.nio.ByteBuffer

--- a/core/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/TransproxyService.kt
@@ -36,7 +36,7 @@ class TransproxyService : Service(), LocalDnsService.Interface {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
             super<LocalDnsService.Interface>.onStartCommand(intent, flags, startId)
 
-    private suspend fun startDNSTunnel() {
+    private fun startDNSTunnel() {
         val proxy = data.proxy!!
         val cmd = arrayListOf(File(applicationInfo.nativeLibraryDir, Executable.SS_TUNNEL).absolutePath,
                 "-t", "10",
@@ -50,7 +50,7 @@ class TransproxyService : Service(), LocalDnsService.Interface {
         data.processes!!.start(cmd)
     }
 
-    private suspend fun startRedsocksDaemon() {
+    private fun startRedsocksDaemon() {
         File(Core.deviceStorage.noBackupFilesDir, "redsocks.conf").writeText("""base {
  log_debug = off;
  log_info = off;

--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -58,7 +58,6 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
          * https://android.googlesource.com/platform/prebuilts/runtime/+/94fec32/appcompat/hiddenapi-light-greylist.txt#9466
          */
         private val getInt: Method = FileDescriptor::class.java.getDeclaredMethod("getInt$")
-
     }
 
     class CloseableFd(val fd: FileDescriptor) : Closeable {

--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -34,9 +34,11 @@ import com.github.shadowsocks.Core
 import com.github.shadowsocks.VpnRequestActivity
 import com.github.shadowsocks.acl.Acl
 import com.github.shadowsocks.core.R
+import com.github.shadowsocks.net.DefaultNetworkListener
+import com.github.shadowsocks.net.LocalSocketListener
+import com.github.shadowsocks.net.Subnet
 import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.Key
-import com.github.shadowsocks.utils.Subnet
 import com.github.shadowsocks.utils.parseNumericAddress
 import com.github.shadowsocks.utils.printLog
 import kotlinx.coroutines.*

--- a/core/src/main/java/com/github/shadowsocks/net/ConcurrentLocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/ConcurrentLocalSocketListener.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *                                                                             *
+ *  Copyright (C) 2019 by Max Lv <max.c.lv@gmail.com>                          *
+ *  Copyright (C) 2019 by Mygod Studio <contact-shadowsocks-android@mygod.be>  *
+ *                                                                             *
+ *  This program is free software: you can redistribute it and/or modify       *
+ *  it under the terms of the GNU General Public License as published by       *
+ *  the Free Software Foundation, either version 3 of the License, or          *
+ *  (at your option) any later version.                                        *
+ *                                                                             *
+ *  This program is distributed in the hope that it will be useful,            *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *  GNU General Public License for more details.                               *
+ *                                                                             *
+ *  You should have received a copy of the GNU General Public License          *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ *                                                                             *
+ *******************************************************************************/
+
+package com.github.shadowsocks.net
+
+import android.net.LocalSocket
+import com.github.shadowsocks.utils.printLog
+import kotlinx.coroutines.*
+import java.io.File
+
+abstract class ConcurrentLocalSocketListener(name: String, socketFile: File) : LocalSocketListener(name, socketFile),
+        CoroutineScope {
+    private val job = SupervisorJob()
+    override val coroutineContext get() = Dispatchers.IO + job + CoroutineExceptionHandler { _, t -> printLog(t) }
+
+    override fun accept(socket: LocalSocket) {
+        launch { super.accept(socket) }
+    }
+
+    suspend fun shutdown() {
+        job.cancel()
+        close()
+        job.join()
+    }
+}

--- a/core/src/main/java/com/github/shadowsocks/net/DefaultNetworkListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/DefaultNetworkListener.kt
@@ -18,7 +18,7 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.bg
+package com.github.shadowsocks.net
 
 import android.annotation.TargetApi
 import android.net.ConnectivityManager

--- a/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
@@ -18,7 +18,7 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.utils
+package com.github.shadowsocks.net
 
 import android.os.SystemClock
 import androidx.lifecycle.MutableLiveData
@@ -28,6 +28,8 @@ import com.github.shadowsocks.Core.app
 import com.github.shadowsocks.acl.Acl
 import com.github.shadowsocks.core.R
 import com.github.shadowsocks.preference.DataStore
+import com.github.shadowsocks.utils.Key
+import com.github.shadowsocks.utils.responseLength
 import kotlinx.coroutines.*
 import java.io.IOException
 import java.net.HttpURLConnection

--- a/core/src/main/java/com/github/shadowsocks/net/LocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/LocalSocketListener.kt
@@ -42,7 +42,8 @@ abstract class LocalSocketListener(name: String, socketFile: File) : Thread(name
     /**
      * Inherited class do not need to close input/output streams as they will be closed automatically.
      */
-    protected abstract fun accept(socket: LocalSocket)
+    protected open fun accept(socket: LocalSocket) = socket.use { acceptInternal(socket) }
+    protected abstract fun acceptInternal(socket: LocalSocket)
     final override fun run() = localSocket.use {
         while (running) {
             try {

--- a/core/src/main/java/com/github/shadowsocks/net/LocalSocketListener.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/LocalSocketListener.kt
@@ -18,7 +18,7 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.bg
+package com.github.shadowsocks.net
 
 import android.net.LocalServerSocket
 import android.net.LocalSocket

--- a/core/src/main/java/com/github/shadowsocks/net/Subnet.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/Subnet.kt
@@ -18,8 +18,9 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.utils
+package com.github.shadowsocks.net
 
+import com.github.shadowsocks.utils.parseNumericAddress
 import java.net.InetAddress
 import java.util.*
 

--- a/core/src/main/java/com/github/shadowsocks/net/TcpFastOpen.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/TcpFastOpen.kt
@@ -18,7 +18,7 @@
  *                                                                             *
  *******************************************************************************/
 
-package com.github.shadowsocks.utils
+package com.github.shadowsocks.net
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull

--- a/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -27,7 +27,7 @@ import com.github.shadowsocks.database.PrivateDatabase
 import com.github.shadowsocks.database.PublicDatabase
 import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.Key
-import com.github.shadowsocks.utils.TcpFastOpen
+import com.github.shadowsocks.net.TcpFastOpen
 import com.github.shadowsocks.utils.parsePort
 import java.net.NetworkInterface
 import java.net.SocketException

--- a/core/src/main/java/com/github/shadowsocks/utils/Utils.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/Utils.kt
@@ -49,8 +49,8 @@ private val parseNumericAddress by lazy {
  *
  * Bug: https://issuetracker.google.com/issues/123456213
  */
-fun String?.parseNumericAddress(): InetAddress? = Os.inet_pton(OsConstants.AF_INET, this) ?:
-        Os.inet_pton(OsConstants.AF_INET6, this)?.let { parseNumericAddress.invoke(null, this) as InetAddress }
+fun String?.parseNumericAddress(): InetAddress? = Os.inet_pton(OsConstants.AF_INET, this)
+        ?: Os.inet_pton(OsConstants.AF_INET6, this)?.let { parseNumericAddress.invoke(null, this) as InetAddress }
 
 fun parsePort(str: String?, default: Int, min: Int = 1025): Int {
     val value = str?.toIntOrNull() ?: default

--- a/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
@@ -28,7 +28,7 @@ import com.github.shadowsocks.bg.BaseService
 import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.Key
-import com.github.shadowsocks.utils.TcpFastOpen
+import com.github.shadowsocks.net.TcpFastOpen
 import com.github.shadowsocks.utils.remove
 import com.takisoft.preferencex.PreferenceFragmentCompat
 

--- a/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
@@ -42,7 +42,7 @@ import com.github.shadowsocks.MainActivity
 import com.github.shadowsocks.R
 import com.github.shadowsocks.ToolbarFragment
 import com.github.shadowsocks.bg.BaseService
-import com.github.shadowsocks.utils.Subnet
+import com.github.shadowsocks.net.Subnet
 import com.github.shadowsocks.utils.asIterable
 import com.github.shadowsocks.utils.resolveResourceId
 import com.github.shadowsocks.widget.UndoSnackbarManager

--- a/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/acl/CustomRulesFragment.kt
@@ -51,6 +51,7 @@ import java.net.IDN
 import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
+import java.util.regex.PatternSyntaxException
 
 class CustomRulesFragment : ToolbarFragment(), Toolbar.OnMenuItemClickListener, ActionMode.Callback {
     companion object {
@@ -128,7 +129,15 @@ class CustomRulesFragment : ToolbarFragment(), Toolbar.OnMenuItemClickListener, 
         private fun validate(template: Int = templateSelector.selectedItemPosition, value: Editable = editText.text) {
             var message = ""
             positive.isEnabled = when (Template.values()[template]) {
-                Template.Generic -> value.isNotEmpty()
+                Template.Generic -> value.toString().run {
+                    try {
+                        if (Subnet.fromString(this) == null) toPattern()
+                        true
+                    } catch (e: PatternSyntaxException) {
+                        message = e.localizedMessage
+                        false
+                    }
+                }
                 Template.Domain -> try {
                     IDN.toASCII(value.toString(), IDN.ALLOW_UNASSIGNED or IDN.USE_STD3_ASCII_RULES)
                     true

--- a/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
@@ -33,7 +33,7 @@ import androidx.lifecycle.get
 import com.github.shadowsocks.MainActivity
 import com.github.shadowsocks.R
 import com.github.shadowsocks.bg.BaseService
-import com.github.shadowsocks.utils.HttpsTest
+import com.github.shadowsocks.net.HttpsTest
 import com.google.android.material.bottomappbar.BottomAppBar
 
 class StatsBar @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null,

--- a/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
+++ b/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
@@ -50,6 +50,8 @@ import com.github.shadowsocks.bg.BaseService
 import com.github.shadowsocks.bg.Executable
 import com.github.shadowsocks.database.Profile
 import com.github.shadowsocks.database.ProfileManager
+import com.github.shadowsocks.net.HttpsTest
+import com.github.shadowsocks.net.TcpFastOpen
 import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.preference.OnPreferenceDataStoreChangeListener
 import com.github.shadowsocks.utils.*


### PR DESCRIPTION
Supersedes https://github.com/shadowsocks/shadowsocks-android/pull/2092. Ready to merge.

> This fixes occasional DNS resolving timeouts when switching profiles in VPN mode, due to race conditions where the DNS request was sent to the VPN tun interface shortly before its tear-down. This also enables the possibility that we can switch profile without recreating another tun interface (contributions are welcome).
> 
> However, in order to make this work, we need to know default network other than current VPN interface. Therefore, we will encounter [`WRITE_SETTINGS` permission bug](https://stackoverflow.com/a/33509180/2245107) on Android 6.0(.0). The current workaround is to use `registerNetworkCallback` so that we will use any default network candidate (possibly mobile data while Wi-Fi is present) as our default network. We also show a Toast prompting user to enable the permission (further improvements are welcome).