### PR TITLE
Use domain name as default value for remoteDns

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/database/Profile.kt
+++ b/core/src/main/java/com/github/shadowsocks/database/Profile.kt
@@ -54,7 +54,7 @@ data class Profile(
         var password: String = "u1rRWTssNv0p",
         var method: String = "aes-256-cfb",
         var route: String = "all",
-        var remoteDns: String = "8.8.8.8",
+        var remoteDns: String = "dns.google",
         var proxyApps: Boolean = false,
         var bypass: Boolean = false,
         var udpdns: Boolean = false,


### PR DESCRIPTION
Works better under IPv6-only environments.