### PR TITLE
Add a key to settings screen

### DIFF
--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                  xmlns:app="http://schemas.android.com/apk/res-auto"
-                  app:initialExpandedChildrenCount="3">
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="settings_screen"
+    app:initialExpandedChildrenCount="3">
     <SwitchPreference android:key="isAutoConnect"
                       android:persistent="false"
                       android:summary="@string/auto_connect_summary"


### PR DESCRIPTION
Set a key on the PreferenceScreen if using initialExpandedChildrenCount. 
the state is correctly saved and restored when the configuration changes (such as when rotating the screen).