### PR TITLE
ipv6 use reserved addr defined in rfc4291

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -56,8 +56,8 @@ class VpnService : BaseVpnService(), LocalDnsService.Interface {
         private const val VPN_MTU = 1500
         private const val PRIVATE_VLAN4_CLIENT = "172.19.0.1"
         private const val PRIVATE_VLAN4_ROUTER = "172.19.0.2"
-        private const val PRIVATE_VLAN6_CLIENT = "fdfe:dcba:9876::1"
-        private const val PRIVATE_VLAN6_ROUTER = "fdfe:dcba:9876::2"
+        private const val PRIVATE_VLAN6_CLIENT = "ddfe:dcba:9876::1"
+        private const val PRIVATE_VLAN6_ROUTER = "ddfe:dcba:9876::2"
 
         /**
          * https://android.googlesource.com/platform/prebuilts/runtime/+/94fec32/appcompat/hiddenapi-light-greylist.txt#9466


### PR DESCRIPTION
# Problem

`fdfe:dcba:9876::1` is an ULA, defined in RFC 4193, which meant for communications among private IPv6 networks.

But in the scenario of VPN application, the interface addresss is actually for NAT6, private address would be translated to communicate with remote servers. This isn't what RFC 4193 ULA meant for.

As result, even when properly configured, open https://test-ipv6.com in browser, still getting a warnning:

```
Your browser has real working IPv6 address - but is avoiding using it. We're concerned about this. [more info]
```

That's caused by apps faceing dual-stack servers, an ULA address had a very low priolity and apps tend to avoid it.

# Resolving

Simply change the ULA address to a reserved block, eg `c000::/3`. ref:  [IANA Address Space](https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.xhtml)

# More info

 * [论 NAT6（IPv6 NAT）](https://zhuanlan.zhihu.com/p/38680594)
 * [Openwrt User guide for NAT6](https://openwrt.org/docs/guide-user/network/ipv6/ipv6.nat6#faq_and_troubleshooting) #Why should the ULA prefix be changed?