### PR TITLE
Stop update notification if channel is closed

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/ServiceNotification.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ServiceNotification.kt
@@ -20,6 +20,7 @@
 
 package com.github.shadowsocks.bg
 
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.BroadcastReceiver
@@ -69,6 +70,7 @@ class ServiceNotification(private val service: BaseService.Interface, profileNam
         }
     }
     private var callbackRegistered = false
+    private var isChannelClosed = false
 
     private val builder = NotificationCompat.Builder(service as Context, channel)
             .setWhen(0)
@@ -89,11 +91,17 @@ class ServiceNotification(private val service: BaseService.Interface, profileNam
             setShowsUserInterface(false)
         }.build()
         if (Build.VERSION.SDK_INT < 24) builder.addAction(closeAction) else builder.addInvisibleAction(closeAction)
-        updateCallback(service.getSystemService<PowerManager>()?.isInteractive != false)
-        service.registerReceiver(this, IntentFilter().apply {
-            addAction(Intent.ACTION_SCREEN_ON)
-            addAction(Intent.ACTION_SCREEN_OFF)
-        })
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelInfo = service.getSystemService<NotificationManager>()?.getNotificationChannel(channel)
+            if (channelInfo?.importance == NotificationManager.IMPORTANCE_NONE) isChannelClosed = true
+        }
+        if (!isChannelClosed) {
+            updateCallback(service.getSystemService<PowerManager>()?.isInteractive != false)
+            service.registerReceiver(this, IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            })
+        }
         show()
     }
 
@@ -115,8 +123,11 @@ class ServiceNotification(private val service: BaseService.Interface, profileNam
     private fun show() = (service as Service).startForeground(1, builder.build())
 
     fun destroy() {
-        (service as Service).unregisterReceiver(this)
-        updateCallback(false)
+        service as Service
+        if (!isChannelClosed) {
+            service.unregisterReceiver(this)
+            updateCallback(false)
+        }
         service.stopForeground(true)
     }
 }


### PR DESCRIPTION
(cherry picked from commit 0058661e14663d27ab52f5ad1c79c9fc6989daf7)
提交修改至上游

在手动修改过通知渠道级别的用户中，直接关闭通知是最多的。因此进行专门的优化以节省电量。

PS: 在Android10上，前台服务的通知级别会强制提升到`LOW`。除非是用户修改，否则不可能为`MIN`及以下（`NotificationManager#IMPORTANCE_MIN`注释）。因此对 #1355 最后的修改很奇怪。