### PR TITLE
add share dns services over lan for mobile interface

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -215,7 +215,7 @@ class VpnService : BaseVpnService(), BaseService.Interface {
                 "--socks-server-addr", "${DataStore.listenAddress}:${DataStore.portProxy}",
                 "--tunmtu", VPN_MTU.toString(),
                 "--sock-path", "sock_path",
-                "--dnsgw", "127.0.0.1:${DataStore.portLocalDns}",
+                "--dnsgw", "${DataStore.listenAddress}:${DataStore.portLocalDns}",
                 "--loglevel", "warning")
         if (profile.ipv6) {
             cmd += "--netif-ip6addr"

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -30,6 +30,9 @@
         app:icon="@drawable/ic_action_dns"
         app:title="@string/port_local_dns"
         app:useSimpleSummaryProvider="true"/>
+    <SwitchPreference
+        app:key="shareOverLan"
+        app:title="@string/share_over_lan"/>
     <EditTextPreference
         app:key="portTransproxy"
         app:title="@string/port_transproxy"


### PR DESCRIPTION
The mobile interface does not have a switch for share over lan which
is presented in the tv interface. Currently sharing dns services over
lan only works if bypass lan is set. Sharing socks5 port works
regardless route config. This is currently not documented and thus may
make some  user confused. I am not knowledgable enough to make sharing
dns services work like sharing other socks5 proxy. Any comments
are welcome.