### PR TITLE
Avoid text truncation in the StatsBar

### DIFF
--- a/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
@@ -72,7 +72,6 @@ class StatsBar @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
     }
 
     private fun setStatus(text: CharSequence) {
-
         TextViewCompat.setAutoSizeTextTypeWithDefaults(statusText,
                 TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE)
         statusText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)

--- a/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/widget/StatsBar.kt
@@ -23,11 +23,13 @@ package com.github.shadowsocks.widget
 import android.content.Context
 import android.text.format.Formatter
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.widget.TooltipCompat
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.widget.TextViewCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenStarted
 import com.github.shadowsocks.MainActivity
@@ -41,7 +43,7 @@ import kotlinx.coroutines.launch
 class StatsBar @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null,
                                          defStyleAttr: Int = R.attr.bottomAppBarStyle) :
         BottomAppBar(context, attrs, defStyleAttr) {
-    private lateinit var statusText: TextView
+    private lateinit var statusText: androidx.appcompat.widget.AppCompatTextView
     private lateinit var txText: TextView
     private lateinit var rxText: TextView
     private lateinit var txRateText: TextView
@@ -70,7 +72,16 @@ class StatsBar @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
     }
 
     private fun setStatus(text: CharSequence) {
+
+        TextViewCompat.setAutoSizeTextTypeWithDefaults(statusText,
+                TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE)
+        statusText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
         statusText.text = text
+        statusText.post {
+            TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(statusText,
+                            1, 16, 1, TypedValue.COMPLEX_UNIT_SP)
+        }
+
         TooltipCompat.setTooltipText(this, text)
     }
 

--- a/mobile/src/main/res/layout/layout_main.xml
+++ b/mobile/src/main/res/layout/layout_main.xml
@@ -105,17 +105,20 @@
 
                 <TextView
                     android:id="@+id/status"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:maxLines="1"
+                    android:maxHeight="100dp"
+                    app:autoSizeTextType="uniform"
+                    app:autoSizeMinTextSize="5sp"
+                    app:autoSizeMaxTextSize="16sp"
+                    app:autoSizeStepGranularity="1sp"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="16sp"
                     android:layout_gravity="fill_horizontal"
                     android:layout_row="2"
                     android:layout_column="0"
                     android:layout_columnSpan="3"
                     android:ellipsize="end"
-                    tools:text="@string/connection_test_available"/>
+                    tools:text="@string/connection_test_available" />
 
             </GridLayout>
 


### PR DESCRIPTION
Fixes #2492 

It seems as if the original intention in this commit https://github.com/shadowsocks/shadowsocks-android/commit/3b6cd416939b14c66e18c260dff0272fa366f5a5 was to use `android:ellipsize="marquee"`, which I think is better than removing `android:maxLines="1"` because if the system zoom and font is set to be very large, the `ServiceButton` may still possibly overlap the 2nd row if there is 2 rows and the 1st row has ads. (and furthermore, I remember the text being marquee when this project was still written in Scala...)

Before
![image](https://user-images.githubusercontent.com/3119646/95122676-72056b00-0783-11eb-8922-41a2b3302b7f.png)
After
![image](https://user-images.githubusercontent.com/3119646/95122688-76318880-0783-11eb-82f3-94e5d0a42984.png)
