### PR TITLE
Fix little problem of profile switching

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -224,8 +224,8 @@ object BaseService {
         fun forceLoad() {
             val (profile, fallback) = Core.currentProfile
                     ?: return stopRunner(false, (this as Context).getString(R.string.profile_empty))
-            if (profile.host.isEmpty() || profile.password.isEmpty() ||
-                    fallback != null && (fallback.host.isEmpty() || fallback.password.isEmpty())) {
+            if (profile.host.isEmpty() || (!profile.method.equals("none") && profile.password.isEmpty()) ||
+                    fallback != null && (fallback.host.isEmpty() || (!fallback.method.equals("none") && fallback.password.isEmpty()))) {
                 stopRunner(false, (this as Context).getString(R.string.proxy_empty))
                 return
             }


### PR DESCRIPTION
由于"NONE"方法的引入在判断逻辑上做了一点小更改，修复在已经连接状态下直接切换到一个使用“NONE”方法且没有输入密码的配置时服务会停止的问题。