### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,8 @@ buildscript {
     }
 
     dependencies {
-        val kotlinVersion = rootProject.extra.get("kotlinVersion").toString()
-        classpath(rootProject.extra.get("androidPlugin").toString())
+        val kotlinVersion = rootProject.extra["kotlinVersion"].toString()
+        classpath(rootProject.extra["androidPlugin"].toString())
         classpath(kotlin("gradle-plugin", kotlinVersion))
         classpath("com.google.android.gms:oss-licenses-plugin:0.10.2")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.4.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven("https://plugins.gradle.org/m2/")
+        gradlePluginPortal()
     }
 
     dependencies {
@@ -19,7 +19,7 @@ buildscript {
         classpath(kotlin("gradle-plugin", kotlinVersion))
         classpath("com.google.android.gms:oss-licenses-plugin:0.10.2")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.4.1")
-        classpath("com.google.gms:google-services:4.3.4")
+        classpath("com.google.gms:google-services:4.3.5")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
         classpath("gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.4.20")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 apply(from = "../repositories.gradle.kts")
 
 dependencies {
-    implementation(rootProject.extra.get("androidPlugin").toString())
-    implementation(kotlin("gradle-plugin", rootProject.extra.get("kotlinVersion").toString()))
+    implementation(rootProject.extra["androidPlugin"].toString())
+    implementation(kotlin("gradle-plugin", rootProject.extra["kotlinVersion"].toString()))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -63,14 +63,14 @@ tasks.clean.dependsOn("cargoClean")
 
 dependencies {
     val coroutinesVersion = "1.4.2"
-    val roomVersion = "2.2.5"
-    val workVersion = "2.5.0-rc01"
+    val roomVersion = "2.2.6"
+    val workVersion = "2.5.0"
 
     api(project(":plugin"))
     api("androidx.appcompat:appcompat:1.2.0")
     api("androidx.core:core-ktx:1.5.0-beta01")
 
-    api("androidx.fragment:fragment-ktx:1.3.0-rc01")
+    api("androidx.fragment:fragment-ktx:1.3.0-rc02")
     api("androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion")
     api("androidx.lifecycle:lifecycle-livedata-core-ktx:$lifecycleVersion")
     api("androidx.preference:preference:1.1.1")
@@ -79,8 +79,8 @@ dependencies {
     api("androidx.work:work-runtime-ktx:$workVersion")
     api("com.google.android.gms:play-services-oss-licenses:17.0.0")
     api("com.google.code.gson:gson:2.8.6")
-    api("com.google.firebase:firebase-analytics-ktx:18.0.1")
-    api("com.google.firebase:firebase-crashlytics:17.3.0")
+    api("com.google.firebase:firebase-analytics-ktx:18.0.2")
+    api("com.google.firebase:firebase-crashlytics:17.3.1")
     api("com.jakewharton.timber:timber:4.7.1")
     api("dnsjava:dnsjava:3.3.1")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -12,15 +12,15 @@ setupApp()
 android.defaultConfig.applicationId = "com.github.shadowsocks"
 
 dependencies {
-    val cameraxVersion = "1.0.0-rc01"
+    val cameraxVersion = "1.0.0-rc02"
 
     implementation("androidx.browser:browser:1.3.0")
     implementation("androidx.camera:camera-camera2:$cameraxVersion")
     implementation("androidx.camera:camera-lifecycle:$cameraxVersion")
-    implementation("androidx.camera:camera-view:1.0.0-alpha20")
+    implementation("androidx.camera:camera-view:1.0.0-alpha21")
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
-    implementation("com.google.mlkit:barcode-scanning:16.1.0")
+    implementation("com.google.mlkit:barcode-scanning:16.1.1")
     implementation("com.google.zxing:core:3.4.1")
     implementation("com.takisoft.preferencex:preferencex-simplemenu:1.1.0")
     implementation("com.twofortyfouram:android-plugin-api-for-locale:1.0.4")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
     api("androidx.core:core-ktx:1.3.2")
     // https://android-developers.googleblog.com/2019/07/android-q-beta-5-update.html
     api("androidx.drawerlayout:drawerlayout:1.1.1")
-    api("com.google.android.material:material:1.2.1")
+    api("com.google.android.material:material:1.3.0")
 }

--- a/repositories.gradle.kts
+++ b/repositories.gradle.kts
@@ -1,6 +1,6 @@
 rootProject.extra.apply {
     set("androidPlugin", "com.android.tools.build:gradle:4.1.2")
-    set("kotlinVersion", "1.4.21")
+    set("kotlinVersion", "1.4.30")
 }
 
 repositories {


### PR DESCRIPTION
- Replace `https://plugins.gradle.org/m2/` with `gradlePluginPortal()`, same address.
- Update dependencies include kotlin 1.4.30
- Replace `get` call with indexing operator