### PR TITLE
Fix windows build failed and allowed build under msys2 or cygwin

### DIFF
--- a/core/src/main/rust/linker-wrapper.py
+++ b/core/src/main/rust/linker-wrapper.py
@@ -6,7 +6,46 @@ import shutil
 import subprocess
 import sys
 
-args = [os.environ['RUST_ANDROID_GRADLE_CC'], os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
+rustcc = os.environ['RUST_ANDROID_GRADLE_CC']
+
+if sys.platform == 'msys' or sys.platform == 'cygwin':
+    import ctypes
+
+    cygdll = 'cygwin1.dll' if sys.platform == 'cygwin' else 'msys-2.0.dll'
+    cygwin = ctypes.cdll.LoadLibrary(cygdll)
+
+    def win2posix(path):
+        CCP_WIN_W_TO_POSIX = 3
+        size = cygwin.cygwin_conv_path(CCP_WIN_W_TO_POSIX, path, 0, 0)
+        retval = ctypes.create_string_buffer(size)
+        cygwin.cygwin_conv_path(CCP_WIN_W_TO_POSIX, path, retval, size)
+        return retval.value.decode()
+
+    rustcc = win2posix(rustcc)
+
+args = [rustcc, os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
+
+linkargfileName = ''
+if (sys.platform == 'msys' or sys.platform == 'cygwin') and len(''.join(args)) > 8191:
+    import codecs
+    import tempfile
+
+    def posix2win(path):
+        CCP_POSIX_TO_WIN_W = 1
+        size = cygwin.cygwin_conv_path(CCP_POSIX_TO_WIN_W, str(path).encode(), 0, 0)
+        retval = ctypes.create_unicode_buffer(size)
+        cygwin.cygwin_conv_path(CCP_POSIX_TO_WIN_W, str(path).encode(), retval, size)
+        return retval.value
+
+    # response file should be use UTF-16 with BOM
+    linkargfile = tempfile.NamedTemporaryFile(delete=False)
+    linkargfile.write(codecs.BOM_UTF16_LE)
+    linkargfile.write('\n'.join(sys.argv[1:]).encode('utf-16-le'))
+    linkargfile.close()
+    linkargfileName = linkargfile.name
+    linkargfileNameW = posix2win(linkargfileName)
+    args = [rustcc, os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG'], '@' + linkargfileNameW]
+
 
 # This only appears when the subprocess call fails, but it's helpful then.
 printable_cmd = ' '.join(pipes.quote(arg) for arg in args)
@@ -21,4 +60,6 @@ if code == 0:
             with open(linkargs[0][1:]) as f:
                 sys_argv = f.read().splitlines()
     shutil.copyfile(sys_argv[sys_argv.index('-o') + 1], os.environ['RUST_ANDROID_GRADLE_TARGET'])
+if linkargfileName != '':
+    os.unlink(linkargfileName)
 sys.exit(code)

--- a/core/src/main/rust/linker-wrapper.py
+++ b/core/src/main/rust/linker-wrapper.py
@@ -14,5 +14,11 @@ print(printable_cmd)
 
 code = subprocess.call(args)
 if code == 0:
-    shutil.copyfile(sys.argv[sys.argv.index('-o') + 1], os.environ['RUST_ANDROID_GRADLE_TARGET'])
+    sys_argv = sys.argv
+    if sys.platform == 'msys' or sys.platform == 'cygwin' or sys.platform == 'win32':
+        linkargs = list(filter(lambda s: s.startswith('@') and s.find('linker-arguments') != -1, sys.argv[1:]))
+        if linkargs != []:
+            with open(linkargs[0][1:]) as f:
+                sys_argv = f.read().splitlines()
+    shutil.copyfile(sys_argv[sys_argv.index('-o') + 1], os.environ['RUST_ANDROID_GRADLE_TARGET'])
 sys.exit(code)


### PR DESCRIPTION
fix #2666 #2711
if linker arguments too long, rust will use response file [link.rs#L1178](https://github.com/rust-lang/rust/blob/d44f647ffcff0e1ff2c0f45b6a0ce9796d80f1ca/compiler/rustc_codegen_ssa/src/back/link.rs#L1178), then output filename detect will failed.

Under msys2 and cygwin `RUST_ANDROID_GRADLE_CC` should convert to unix path  when use native python.

Under msys2 and cygwin environment the response file will convert to full arguments when run under winshell, so need convert linker arguments back to response file to avoid `Argument list too long`
