### PR TITLE
Bring back semitransparent TV app via build variants

### DIFF
--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -9,7 +9,22 @@ plugins {
 
 setupApp()
 
-android.defaultConfig.applicationId = "com.github.shadowsocks.tv"
+android {
+    defaultConfig {
+        applicationId = "com.github.shadowsocks.tv"
+        buildConfigField("boolean", "FULLSCREEN", "false")
+    }
+    flavorDimensions("market")
+    productFlavors {
+        create("freedom") {
+            dimension("market")
+        }
+        create("google") {
+            dimension("market")
+            buildConfigField("boolean", "FULLSCREEN", "true")
+        }
+    }
+}
 
 dependencies {
     implementation("androidx.leanback:leanback-preference:1.1.0-rc01")

--- a/tv/src/freedom/res/values/styles.xml
+++ b/tv/src/freedom/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Shadowsocks.TV" parent="@style/Theme.Shadowsocks.TVBase">
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+</resources>

--- a/tv/src/main/java/com/github/shadowsocks/tv/MainFragment.kt
+++ b/tv/src/main/java/com/github/shadowsocks/tv/MainFragment.kt
@@ -62,8 +62,10 @@ class MainFragment : LeanbackSettingsFragmentCompat() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<View>(R.id.settings_preference_fragment_container).updateLayoutParams {
-            width = ViewGroup.LayoutParams.MATCH_PARENT
+        if (BuildConfig.FULLSCREEN) {
+            view.findViewById<View>(R.id.settings_preference_fragment_container).updateLayoutParams {
+                width = ViewGroup.LayoutParams.MATCH_PARENT
+            }
         }
     }
 }

--- a/tv/src/main/res/values/styles.xml
+++ b/tv/src/main/res/values/styles.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Shadowsocks.TV" parent="@style/Theme.AppCompat.Leanback">
+    <style name="Theme.Shadowsocks.TVBase" parent="@style/Theme.AppCompat.Leanback">
         <item name="android:colorAccent">@color/material_accent_200</item>
         <item name="android:colorButtonNormal">@color/material_accent_200</item>
         <item name="android:colorPrimary">@color/color_primary</item>
         <item name="android:colorPrimaryDark">@color/color_primary_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Shadowsocks.TV</item>
     </style>
+    <style name="Theme.Shadowsocks.TV" parent="@style/Theme.Shadowsocks.TVBase" />
     <style name="PreferenceThemeOverlay.Shadowsocks.TV" parent="@style/PreferenceThemeOverlay.v14.Leanback">
         <item name="android:colorAccent">@color/material_accent_200</item>
         <item name="android:colorButtonNormal">@color/material_accent_200</item>


### PR DESCRIPTION
This creates two variants for tv, freedom containing the original design, and google containing one matching Google's nonsense guideline. The former should be published on GitHub and elsewhere.

**Needs testing**.