### PR TITLE
Changing test url from cp.cloudflare.com

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
@@ -82,7 +82,7 @@ class HttpsTest : ViewModel() {
     fun testConnection() {
         cancelTest()
         status.value = Status.Testing
-        val url = URL("https://cp.cloudflare.com")
+        val url = URL("http://detectportal.firefox.com/success.txt")
         val conn = (if (DataStore.serviceMode != Key.modeVpn) {
             url.openConnection(Proxy(Proxy.Type.SOCKS, DataStore.proxyAddress))
         } else url.openConnection()) as HttpURLConnection


### PR DESCRIPTION
Hi,
Due to the fact that a large part of the requests sent to cloudflare.com are blocked in some countries such as Iran, in many cases it is not possible to test the connection for users and thus it is not possible to connect to the server.

One of the most suitable URLs, which practically cannot be limited due to the use of a huge amount of users, is :

`http://detectportal.firefox.com/success.txt.`

Therefore, most of the users' problems will be solved through