### PR TITLE
Hotfix for password checking fail

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -36,6 +36,7 @@ import org.json.JSONObject
 import java.io.File
 import java.net.URI
 import java.net.URISyntaxException
+import java.util.function.Consumer
 
 /**
  * This class sets up environment for ss-local.
@@ -50,13 +51,15 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
             "cipher ${profile.method} is deprecated."
         }
         // check the key format for aead-2022-cipher
-        require(profile.method !in setOf(
-            "2022-blake3-aes-128-gcm",
-            "2022-blake3-aes-256-gcm",
-            "2022-blake3-chacha20-poly1305",
-        ) || Base64.decode(profile.password, Base64.DEFAULT).size in arrayOf(16, 32)) {
-            "The Base64 Key is invalid."
-        }
+        profile.password.split(":").forEach(Consumer {
+            require(profile.method !in setOf(
+                "2022-blake3-aes-128-gcm",
+                "2022-blake3-aes-256-gcm",
+                "2022-blake3-chacha20-poly1305",
+            ) || Base64.decode(it, Base64.DEFAULT).size in arrayOf(16, 32)) {
+                "The Base64 Key is invalid."
+            }
+        })
     }
 
     private var configFile: File? = null

--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -36,7 +36,6 @@ import org.json.JSONObject
 import java.io.File
 import java.net.URI
 import java.net.URISyntaxException
-import java.util.function.Consumer
 
 /**
  * This class sets up environment for ss-local.
@@ -51,15 +50,17 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
             "cipher ${profile.method} is deprecated."
         }
         // check the key format for aead-2022-cipher
-        profile.password.split(":").forEach(Consumer {
-            require(profile.method !in setOf(
+        if (profile.method !in setOf(
                 "2022-blake3-aes-128-gcm",
                 "2022-blake3-aes-256-gcm",
                 "2022-blake3-chacha20-poly1305",
-            ) || Base64.decode(it, Base64.DEFAULT).size in arrayOf(16, 32)) {
-                "The Base64 Key is invalid."
+            )) {
+            for (pwd in profile.password.split(":")) {
+                require(Base64.decode(pwd, Base64.DEFAULT).size in arrayOf(16, 32)) {
+                    "The Base64 Key is invalid."
+                }
             }
-        })
+        }
     }
 
     private var configFile: File? = null


### PR DESCRIPTION
可能存在`iPSK:uPSK`格式的密码。
如果要在客户端检测，要先以`:`做分组，然后对分组后的psk做检测。
Ref: https://github.com/shadowsocks/shadowsocks-android/commit/243cafd41d0712da1f5693067f1f9b0fc6408645#r102304121