### PR TITLE
Add githubusercontent.com to gfwlist

### DIFF
--- a/core/src/main/assets/acl/bypass-china.acl
+++ b/core/src/main/assets/acl/bypass-china.acl
@@ -8910,6 +8910,7 @@
 (?:^|\.)girlbanker\.com$
 (?:^|\.)git\.io$
 (?:^|\.)github\.com$
+(?:^|\.)githubusercontent\.com$
 (?:^|\.)gizlen\.net$
 (?:^|\.)gjczz\.com$
 (?:^|\.)glass8\.eu$

--- a/core/src/main/assets/acl/bypass-lan-china.acl
+++ b/core/src/main/assets/acl/bypass-lan-china.acl
@@ -8927,6 +8927,7 @@
 (?:^|\.)girlbanker\.com$
 (?:^|\.)git\.io$
 (?:^|\.)github\.com$
+(?:^|\.)githubusercontent\.com$
 (?:^|\.)gizlen\.net$
 (?:^|\.)gjczz\.com$
 (?:^|\.)glass8\.eu$

--- a/core/src/main/assets/acl/gfwlist.acl
+++ b/core/src/main/assets/acl/gfwlist.acl
@@ -1875,6 +1875,7 @@
 (?:^|\.)girlbanker\.com$
 (?:^|\.)git\.io$
 (?:^|\.)github\.com$
+(?:^|\.)githubusercontent\.com$
 (?:^|\.)gizlen\.net$
 (?:^|\.)gjczz\.com$
 (?:^|\.)glass8\.eu$


### PR DESCRIPTION
raw.githubusercontent.com is polluted to 0.0.0.0 in some cities, making raw files in github inaccessable when using the builtin bypass route.