### PR TITLE
fix implicit-function-declaration error when updating NDK to r26+

### DIFF
--- a/buildSrc/src/main/kotlin/Helpers.kt
+++ b/buildSrc/src/main/kotlin/Helpers.kt
@@ -68,7 +68,7 @@ fun Project.setupCore() {
             warning += "RestrictedApi"
             disable += "UseAppTint"
         }
-        ndkVersion = "25.1.8937393"
+        ndkVersion = "27.0.12077973"
     }
     dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.0.2")
 }

--- a/core/src/main/jni/Android.mk
+++ b/core/src/main/jni/Android.mk
@@ -33,6 +33,7 @@ LOCAL_MODULE := event
 LOCAL_SRC_FILES := $(addprefix libevent/, $(LIBEVENT_SOURCES))
 LOCAL_CFLAGS := -I$(LOCAL_PATH)/libevent \
 	-I$(LOCAL_PATH)/libevent/include \
+	-Wno-error=implicit-function-declaration
 
 include $(BUILD_STATIC_LIBRARY)
 
@@ -66,7 +67,7 @@ LOCAL_STATIC_LIBRARIES := libevent
 
 LOCAL_MODULE := redsocks
 LOCAL_SRC_FILES := $(addprefix redsocks/, $(REDSOCKS_SOURCES))
-LOCAL_CFLAGS := -std=gnu99 -DUSE_IPTABLES \
+LOCAL_CFLAGS := -std=gnu99 -DUSE_IPTABLES -D_GNU_SOURCE\
 	-I$(LOCAL_PATH)/redsocks \
 	-I$(LOCAL_PATH)/libevent/include \
 	-I$(LOCAL_PATH)/libevent

--- a/core/src/main/jni/Android.mk
+++ b/core/src/main/jni/Android.mk
@@ -26,6 +26,7 @@ include $(CLEAR_VARS)
 
 LIBEVENT_SOURCES := \
 	buffer.c bufferevent.c event.c \
+	bufferevent_pair.c bufferevent_filter.c \
 	bufferevent_sock.c bufferevent_ratelim.c \
 	evthread.c log.c evutil.c evutil_rand.c evutil_time.c evmap.c epoll.c poll.c signal.c select.c
 
@@ -67,7 +68,7 @@ LOCAL_STATIC_LIBRARIES := libevent
 
 LOCAL_MODULE := redsocks
 LOCAL_SRC_FILES := $(addprefix redsocks/, $(REDSOCKS_SOURCES))
-LOCAL_CFLAGS := -std=gnu99 -DUSE_IPTABLES -D_GNU_SOURCE\
+LOCAL_CFLAGS := -std=gnu99 -DUSE_IPTABLES -D_GNU_SOURCE \
 	-I$(LOCAL_PATH)/redsocks \
 	-I$(LOCAL_PATH)/libevent/include \
 	-I$(LOCAL_PATH)/libevent
@@ -85,6 +86,7 @@ LOCAL_CFLAGS += -DBADVPN_THREADWORK_USE_PTHREAD -DBADVPN_LINUX -DBADVPN_BREACTOR
 LOCAL_CFLAGS += -DBADVPN_USE_SIGNALFD -DBADVPN_USE_EPOLL
 LOCAL_CFLAGS += -DBADVPN_LITTLE_ENDIAN -DBADVPN_THREAD_SAFE
 LOCAL_CFLAGS += -DNDEBUG -DANDROID
+LOCAL_CFLAGS += -Wno-parentheses -Wno-unused-value
 # LOCAL_CFLAGS += -DTUN2SOCKS_JNI
 
 LOCAL_STATIC_LIBRARIES := libancillary


### PR DESCRIPTION
https://github.com/android/ndk/wiki/Changelog-r26#changes

Since NDK r26, Clang now treats -Wimplicit-function-declaration as an error rather than a warning in C11 and newer.

In the submodules, function `pipe2` in `redsocks.c` from `redsocks` and function `arc4random_addrandom` in `evutil_rand.c` from `libevent` are implicitly declared.
