### PR TITLE
Fix a warning from sslocal logcat output

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -85,6 +85,7 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
             config.put("plugin", path).put("plugin_opts", opts.toString())
         }
         config.put("dns", "system")
+        config.put("mode", mode)
         config.put("locals", JSONArray().apply {
             // local SOCKS5 proxy
             put(JSONObject().apply {


### PR DESCRIPTION
When the mode `tcp_and_udp` is enabled in shadowsocks-android, it will have a sslocal config like this:
```
{
    "locals": [
        {
            "local_address": "127.0.0.1",
            "local_port": 1080,
	    "mode": "tcp_and_udp"
        }
    ],
    "server": "1.1.1.1",
    "server_port": 12345,
    "password": "xxxxxx",
    "method": "aes-256-gcm"
}
```
which will output a warning in logcat output, this can be reproduce with `sslocal -c config.json -v`
```
WARN main ThreadId(01) shadowsocks_service::local::loadbalancing::ping_balancer: no valid UDP server serving for UDP clients, consider disable UDP with "mode": "tcp_only", currently chose 1.1.1.1:12345
```
This warning is explained with great detail [here](https://github.com/shadowsocks/shadowsocks-rust/issues/1632).

Adding the mode to the global scope dismisses this warning.