### PR TITLE
Add shareOverLan switch for mobile version

### DIFF
--- a/core/src/main/rust/linker-wrapper.py
+++ b/core/src/main/rust/linker-wrapper.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import pipes
 import shutil
 import subprocess
 import sys
@@ -24,6 +23,15 @@ if sys.platform == 'msys' or sys.platform == 'cygwin':
     rustcc = win2posix(rustcc)
 
 args = [rustcc, os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
+
+def cmd_quote(string):
+    import sys
+    if int(sys.version[2]) < 3:
+        import pipes
+        return pipes.quote(string)
+    else:
+        import shlex
+        return shlex.quote(string)
 
 def update_in_place(arglist):
     # The `gcc` library is not included starting from NDK version 23.
@@ -68,7 +76,7 @@ if (sys.platform == 'msys' or sys.platform == 'cygwin') and len(''.join(args)) >
 
 
 # This only appears when the subprocess call fails, but it's helpful then.
-printable_cmd = " ".join(pipes.quote(arg) for arg in args)
+printable_cmd = " ".join(cmd_quote(arg) for arg in args)
 print(printable_cmd)
 
 code = subprocess.call(args)

--- a/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
@@ -53,6 +53,7 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
         } else canToggleLocked.remove()
 
         val serviceMode = findPreference<Preference>(Key.serviceMode)!!
+        val shareOverLan = findPreference<Preference>(Key.shareOverLan)!!
         val portProxy = findPreference<EditTextPreference>(Key.portProxy)!!
         portProxy.setOnBindEditTextListener(EditTextPreferenceModifiers.Port)
         val portLocalDns = findPreference<EditTextPreference>(Key.portLocalDns)!!
@@ -66,6 +67,7 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
         val listener: (BaseService.State) -> Unit = {
             val stopped = it == BaseService.State.Stopped
             serviceMode.isEnabled = stopped
+            shareOverLan.isEnabled = stopped
             portProxy.isEnabled = stopped
             portLocalDns.isEnabled = stopped
             if (stopped) onServiceModeChange.onPreferenceChange(serviceMode, DataStore.serviceMode) else {

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -20,6 +20,9 @@
         app:defaultValue="vpn"
         app:title="@string/service_mode"
         app:useSimpleSummaryProvider="true"/>
+    <SwitchPreference
+        app:key="shareOverLan"
+        app:title="@string/share_over_lan"/>
     <EditTextPreference
         app:key="portProxy"
         app:icon="@drawable/ic_maps_directions_boat"


### PR DESCRIPTION
Hello, 

Added `shareOverLan` switch in settings for Mobile edition
Behavior consistent with TV edition configuration.

And minor fix python 3.13

bye