### PR TITLE
Enable TCP_NODELAY

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/ProxyInstance.kt
@@ -86,6 +86,7 @@ class ProxyInstance(val profile: Profile, private val route: String = profile.ro
         }
         config.put("dns", "unix://local_dns_path")
         config.put("mode", mode)
+        config.put("no_delay", true)
         config.put("locals", JSONArray().apply {
             // local SOCKS5 proxy
             put(JSONObject().apply {


### PR DESCRIPTION
Chrome, Firefox and Go enable `TCP_NODELAY` by default, and we should do the same.
In addition, `badvpn/tun2socks` enabled `TCP_NODELAY` almost a decade ago.