### PR TITLE
VPN flags are now opt-in

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/acl/AclSyncer.kt
+++ b/core/src/main/java/com/github/shadowsocks/acl/AclSyncer.kt
@@ -35,6 +35,7 @@ import androidx.work.WorkerParameters
 import com.github.shadowsocks.Core
 import com.github.shadowsocks.Core.app
 import com.github.shadowsocks.core.BuildConfig
+import com.github.shadowsocks.preference.DataStore
 import com.github.shadowsocks.utils.useCancellable
 import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
@@ -68,7 +69,8 @@ class AclSyncer(context: Context, workerParams: WorkerParameters) : CoroutineWor
 
     override suspend fun doWork(): Result = try {
         val route = inputData.getString(KEY_ROUTE)!!
-        val connection = URL("https://shadowsocks.org/acl/android/v1/$route.acl").openConnection() as HttpURLConnection
+        val connection = URL("https://shadowsocks.org/acl/android/v1/$route.acl")
+            .openConnection(DataStore.proxy) as HttpURLConnection
         val acl = connection.useCancellable { inputStream.bufferedReader().use { it.readText() } }
         Acl.getFile(route).printWriter().use { it.write(acl) }
         Result.success()

--- a/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/VpnService.kt
@@ -166,8 +166,8 @@ class VpnService : BaseVpnService(), BaseService.Interface {
 
         if (profile.ipv6) builder.addAddress(PRIVATE_VLAN6_CLIENT, 126)
 
+        val me = packageName
         if (profile.proxyApps) {
-            val me = packageName
             profile.individual.split('\n')
                     .filter { it != me }
                     .forEach {
@@ -178,7 +178,9 @@ class VpnService : BaseVpnService(), BaseService.Interface {
                             Timber.w(ex)
                         }
                     }
-            if (!profile.bypass) builder.addAllowedApplication(me)
+            if (profile.bypass) builder.addDisallowedApplication(me)
+        } else {
+            builder.addDisallowedApplication(me)
         }
 
         when (profile.route) {

--- a/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.ViewModel
 import com.github.shadowsocks.Core.app
 import com.github.shadowsocks.core.R
 import com.github.shadowsocks.preference.DataStore
-import com.github.shadowsocks.utils.Key
 import com.github.shadowsocks.utils.useCancellable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -35,7 +34,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.io.IOException
 import java.net.HttpURLConnection
-import java.net.Proxy
 import java.net.URL
 import java.net.URLConnection
 
@@ -83,9 +81,7 @@ class HttpsTest : ViewModel() {
         cancelTest()
         status.value = Status.Testing
         val url = URL("https://cp.cloudflare.com")
-        val conn = (if (DataStore.serviceMode != Key.modeVpn) {
-            url.openConnection(Proxy(Proxy.Type.SOCKS, DataStore.proxyAddress))
-        } else url.openConnection()) as HttpURLConnection
+        val conn = url.openConnection(DataStore.proxy) as HttpURLConnection
         conn.setRequestProperty("Connection", "close")
         conn.instanceFollowRedirects = false
         conn.useCaches = false

--- a/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -30,6 +30,7 @@ import com.github.shadowsocks.utils.DirectBoot
 import com.github.shadowsocks.utils.Key
 import com.github.shadowsocks.utils.parsePort
 import java.net.InetSocketAddress
+import java.net.Proxy
 
 object DataStore : OnPreferenceDataStoreChangeListener {
     val publicStore = RoomPreferenceDataStore(PublicDatabase.kvPairDao)
@@ -68,7 +69,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var portProxy: Int
         get() = getLocalPort(Key.portProxy, 1080)
         set(value) = publicStore.putString(Key.portProxy, value.toString())
-    val proxyAddress get() = InetSocketAddress("127.0.0.1", portProxy)
+    val proxy get() = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", portProxy))
     var portLocalDns: Int
         get() = getLocalPort(Key.portLocalDns, 5450)
         set(value) = publicStore.putString(Key.portLocalDns, value.toString())


### PR DESCRIPTION
This re-implements #1742. This allows plugin developers to use the default network directly rather than forcing them to use `protect_path`. They can still opt in to use `protect_path` to make sure that the correct underlying network is used but given the complexity (no plugins are implemented in JVM) and the small marginal benefits, I don't expect most to do this.