### PR TITLE
Remove ABI splits in favor of AAB delivery

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           SKIP_EMULATOR_BOOT: "true"
           ADB: adb
-          APK: ${{ github.workspace }}/mobile/build/outputs/apk/debug/mobile-x86_64-debug.apk
+          APK: ${{ github.workspace }}/mobile/build/outputs/apk/debug/mobile-debug.apk
           SSSERVER: ${{ github.workspace }}/core/src/main/rust/shadowsocks-rust/target/release/ssserver
 
       - name: Upload screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ release/
 # release apks
 *.apk
 .DS_Store
+CLAUDE.md

--- a/buildSrc/src/main/kotlin/Helpers.kt
+++ b/buildSrc/src/main/kotlin/Helpers.kt
@@ -92,10 +92,6 @@ fun Project.setupApp() {
         }
         lint.disable += "RemoveWorkManagerInitializer"
         packagingOptions.jniLibs.useLegacyPackaging = true
-        splits.abi {
-            isEnable = true
-            isUniversalApk = true
-        }
     }
 
     dependencies.add("implementation", project(":core"))

--- a/release.sh
+++ b/release.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
 release=$1
-cp mobile/build/outputs/apk/release/mobile-armeabi-v7a-release.apk         shadowsocks-armeabi-v7a-"${release}".apk
-cp mobile/build/outputs/apk/release/mobile-arm64-v8a-release.apk           shadowsocks-arm64-v8a-"${release}".apk
-cp mobile/build/outputs/apk/release/mobile-x86-release.apk                 shadowsocks-x86-"${release}".apk
-cp mobile/build/outputs/apk/release/mobile-x86_64-release.apk              shadowsocks-x86_64-"${release}".apk
-cp mobile/build/outputs/apk/release/mobile-universal-release.apk           shadowsocks--universal-"${release}".apk
-cp tv/build/outputs/apk/freedom/release/tv-freedom-armeabi-v7a-release.apk shadowsocks-tv-armeabi-v7a-"${release}".apk
-cp tv/build/outputs/apk/freedom/release/tv-freedom-arm64-v8a-release.apk   shadowsocks-tv-arm64-v8a-"${release}".apk
-cp tv/build/outputs/apk/freedom/release/tv-freedom-x86-release.apk         shadowsocks-tv-x86-"${release}".apk
-cp tv/build/outputs/apk/freedom/release/tv-freedom-x86_64-release.apk      shadowsocks-tv-x86_64-"${release}".apk
-cp tv/build/outputs/apk/freedom/release/tv-freedom-universal-release.apk   shadowsocks-tv-universal-"${release}".apk
+cp mobile/build/outputs/bundle/release/mobile-release.aab         shadowsocks-"${release}".aab
+cp tv/build/outputs/bundle/freedomRelease/tv-freedom-release.aab   shadowsocks-tv-"${release}".aab

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 EMULATOR="${EMULATOR:-/Volumes/Data/workspace/android/emulator/emulator}"
 ADB="${ADB:-/Volumes/Data/workspace/android/platform-tools/adb}"
 AVD="${AVD:-Medium_Phone_API_36.1}"
-APK="${APK:-$SCRIPT_DIR/mobile/build/outputs/apk/debug/mobile-arm64-v8a-debug.apk}"
+APK="${APK:-$SCRIPT_DIR/mobile/build/outputs/apk/debug/mobile-debug.apk}"
 SSSERVER="${SSSERVER:-$SCRIPT_DIR/core/src/main/rust/shadowsocks-rust/target/release/ssserver}"
 PKG="com.github.shadowsocks"
 


### PR DESCRIPTION
## Summary
- Remove `splits.abi` block from `Helpers.kt` — ABI splits are incompatible with AAB (`bundleRelease` fails with "Multiple shrunk-resources files found"), and AAB already handles per-device ABI delivery natively
- Update `release.sh` to copy AAB outputs instead of per-ABI APKs
- Fix APK paths in E2E test and CI scripts to use universal APK name

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [x] `./gradlew :mobile:bundleRelease` builds successfully
- [x] E2E tests pass (4/4: tun0, DNS, TCP x2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)