### PR TITLE
Fix profile JSON import broken by trailing newline

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/database/Profile.kt
+++ b/core/src/main/java/com/github/shadowsocks/database/Profile.kt
@@ -230,7 +230,10 @@ data class Profile(
 
         fun parseJson(json: String, feature: Profile? = null, create: (Profile) -> Profile) {
             JsonParser(feature).run {
-                JSONTokener(json).apply { while (more()) process(nextValue()) }
+                // Single root value, matching the pre-gson-removal `.single()` semantics.
+                // `JSONTokener.more()` reports true on trailing whitespace, so a `while (more())`
+                // loop throws JSONException on the standard trailing newline of any imported file.
+                process(JSONTokener(json).nextValue())
                 for (i in indices) {
                     val fallback = fallbackMap.remove(this[i])
                     this[i] = create(this[i])


### PR DESCRIPTION
The gson→org.json migration in df4d65cb wrapped the root-value read in `while (JSONTokener.more()) process(nextValue())`, but JSONTokener.more() reports true on trailing whitespace. Every JSON file ending with a newline (i.e. essentially every file) hits a second nextValue() call that runs off the end and throws JSONException, before finalize() persists the parsed profile.

Restore the pre-migration single-value semantic.