### PR TITLE
Bind local DNS before starting proxy

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -244,6 +244,8 @@ object BaseService {
             val context = if (Build.VERSION.SDK_INT < 24 || Core.user.isUserUnlocked) app else Core.deviceStorage
             val configRoot = context.noBackupFilesDir
             val udpFallback = data.udpFallback
+            // ss-local can resolve the remote server hostname as soon as it starts, so bind the local DNS socket first.
+            data.localDns = LocalDnsWorker(this::rawResolver).apply { start() }
             data.proxy!!.start(this,
                     File(Core.deviceStorage.noBackupFilesDir, "stat_main"),
                     File(configRoot, CONFIG_FILE),
@@ -254,7 +256,6 @@ object BaseService {
                     File(Core.deviceStorage.noBackupFilesDir, "stat_udp"),
                     File(configRoot, CONFIG_FILE_UDP),
                     "udp_only", false)
-            data.localDns = LocalDnsWorker(this::rawResolver).apply { start() }
         }
 
         fun startRunner() {


### PR DESCRIPTION
Summary:
- Start LocalDnsWorker before launching ss-local.
- Avoid hostname resolution racing the unix://local_dns_path DNS socket at startup.
- Keep ss-local on the local DNS socket instead of reverting to system DNS.

Why:
ss-local can resolve the remote server hostname immediately after it starts. When the config points DNS at unix://local_dns_path, the Unix socket needs to be bound first; otherwise domain-based profiles can fail during startup with empty resolution results.

Closes #3246.
Refs #3232.
Refs #3223.

Validation:
- git diff --check
- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/andy/Library/Android/sdk ./gradlew :core:compileDebugKotlin

Please preserve author attribution if this PR is squashed or reworked:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
