### PR TITLE
Proxy UDP fallback for hostname ACL routes

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -336,7 +336,8 @@ object BaseService {
             try {
                 data.proxy = ProxyInstance(profile)
                 data.udpFallback = if (fallback == null) null else ProxyInstance(fallback, when (profile.route) {
-                    // UDP relay sees IP endpoints, so hostname-only ACL routes would bypass the selected fallback.
+                    // UDP relay sees IP endpoints, so GFWLIST and mixed custom ACL routes need
+                    // the selected fallback.
                     Acl.GFWLIST, Acl.CUSTOM_RULES -> Acl.ALL
                     else -> profile.route
                 })

--- a/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
+++ b/core/src/main/java/com/github/shadowsocks/bg/BaseService.kt
@@ -335,7 +335,11 @@ object BaseService {
             val (profile, fallback) = expanded
             try {
                 data.proxy = ProxyInstance(profile)
-                data.udpFallback = if (fallback == null) null else ProxyInstance(fallback, profile.route)
+                data.udpFallback = if (fallback == null) null else ProxyInstance(fallback, when (profile.route) {
+                    // UDP relay sees IP endpoints, so hostname-only ACL routes would bypass the selected fallback.
+                    Acl.GFWLIST, Acl.CUSTOM_RULES -> Acl.ALL
+                    else -> profile.route
+                })
             } catch (e: IllegalArgumentException) {
                 data.notification = createNotification("")
                 stopRunner(false, e.message)


### PR DESCRIPTION
Summary:
- Route UDP fallback with `all` for gfwlist/custom-rules profiles.
- Keep the existing route behavior for subnet/IP-based routes.

Why:
UDP relay decisions are made against IP endpoints. Hostname-heavy ACLs such as gfwlist and custom-rules can therefore bypass the selected UDP fallback even when the user configured one, which prevents QUIC/HTTP3 traffic from reaching the fallback server.

Closes #3070.

Validation:
- git diff --check
- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/andy/Library/Android/sdk ./gradlew :core:compileDebugKotlin

Please preserve author attribution if this PR is squashed or reworked:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
