### PR TITLE
Make connection test URL editable

### DIFF
--- a/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
@@ -80,8 +80,13 @@ class HttpsTest : ViewModel() {
     fun testConnection() {
         cancelTest()
         status.value = Status.Testing
-        val url = URL("https://cp.cloudflare.com")
-        val conn = url.openConnection(DataStore.proxy) as HttpURLConnection
+        val conn = try {
+            URL(DataStore.connectionTestUrl).openConnection(DataStore.proxy) as? HttpURLConnection
+                    ?: throw IOException("URL is not HTTP(S)")
+        } catch (e: IOException) {
+            status.value = Status.Error.IOFailure(e)
+            return
+        }
         conn.setRequestProperty("Connection", "close")
         conn.instanceFollowRedirects = false
         conn.useCaches = false

--- a/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
+++ b/core/src/main/java/com/github/shadowsocks/net/HttpsTest.kt
@@ -33,9 +33,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.io.IOException
-import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLConnection
+import javax.net.ssl.HttpsURLConnection
 
 /**
  * Based on: https://android.googlesource.com/platform/frameworks/base/+/b19a838/services/core/java/com/android/server/connectivity/NetworkMonitor.java#1071
@@ -81,8 +81,8 @@ class HttpsTest : ViewModel() {
         cancelTest()
         status.value = Status.Testing
         val conn = try {
-            URL(DataStore.connectionTestUrl).openConnection(DataStore.proxy) as? HttpURLConnection
-                    ?: throw IOException("URL is not HTTP(S)")
+            URL(DataStore.connectionTestUrl).openConnection(DataStore.proxy) as? HttpsURLConnection
+                    ?: throw IOException("URL is not HTTPS")
         } catch (e: IOException) {
             status.value = Status.Error.IOFailure(e)
             return

--- a/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -78,7 +78,8 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var portTransproxy: Int
         get() = getLocalPort(Key.portTransproxy, 8200)
         set(value) = publicStore.putString(Key.portTransproxy, value.toString())
-    val connectionTestUrl get() = publicStore.getString(Key.connectionTestUrl) ?: DEFAULT_CONNECTION_TEST_URL
+    val connectionTestUrl get() = publicStore.getString(Key.connectionTestUrl)?.trim()?.takeIf { it.isNotEmpty() }
+            ?: DEFAULT_CONNECTION_TEST_URL
 
     /**
      * Initialize settings that have complicated default values.

--- a/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/DataStore.kt
@@ -33,6 +33,8 @@ import java.net.InetSocketAddress
 import java.net.Proxy
 
 object DataStore : OnPreferenceDataStoreChangeListener {
+    private const val DEFAULT_CONNECTION_TEST_URL = "https://cp.cloudflare.com"
+
     val publicStore = RoomPreferenceDataStore(PublicDatabase.kvPairDao)
     // privateStore will only be used as temp storage for ProfileConfigFragment
     val privateStore = RoomPreferenceDataStore(PrivateDatabase.kvPairDao)
@@ -76,6 +78,7 @@ object DataStore : OnPreferenceDataStoreChangeListener {
     var portTransproxy: Int
         get() = getLocalPort(Key.portTransproxy, 8200)
         set(value) = publicStore.putString(Key.portTransproxy, value.toString())
+    val connectionTestUrl get() = publicStore.getString(Key.connectionTestUrl) ?: DEFAULT_CONNECTION_TEST_URL
 
     /**
      * Initialize settings that have complicated default values.
@@ -85,6 +88,9 @@ object DataStore : OnPreferenceDataStoreChangeListener {
         if (publicStore.getString(Key.portProxy) == null) portProxy = portProxy
         if (publicStore.getString(Key.portLocalDns) == null) portLocalDns = portLocalDns
         if (publicStore.getString(Key.portTransproxy) == null) portTransproxy = portTransproxy
+        if (publicStore.getString(Key.connectionTestUrl) == null) {
+            publicStore.putString(Key.connectionTestUrl, connectionTestUrl)
+        }
     }
 
     var editingId: Long?

--- a/core/src/main/java/com/github/shadowsocks/preference/EditTextPreferenceModifiers.kt
+++ b/core/src/main/java/com/github/shadowsocks/preference/EditTextPreferenceModifiers.kt
@@ -22,6 +22,7 @@ package com.github.shadowsocks.preference
 
 import android.graphics.Typeface
 import android.text.InputFilter
+import android.text.InputType
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.preference.EditTextPreference
@@ -39,6 +40,14 @@ object EditTextPreferenceModifiers {
         override fun onBindEditText(editText: EditText) {
             editText.inputType = EditorInfo.TYPE_CLASS_NUMBER
             editText.filters = portLengthFilter
+            editText.setSingleLine()
+            editText.setSelection(editText.text.length)
+        }
+    }
+
+    object Url : EditTextPreference.OnBindEditTextListener {
+        override fun onBindEditText(editText: EditText) {
+            editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI
             editText.setSingleLine()
             editText.setSelection(editText.text.length)
         }

--- a/core/src/main/java/com/github/shadowsocks/utils/Constants.kt
+++ b/core/src/main/java/com/github/shadowsocks/utils/Constants.kt
@@ -40,6 +40,7 @@ object Key {
     const val portProxy = "portProxy"
     const val portLocalDns = "portLocalDns"
     const val portTransproxy = "portTransproxy"
+    const val connectionTestUrl = "connectionTestUrl"
 
     const val route = "route"
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
   <string name="port_proxy">SOCKS5 proxy port</string>
   <string name="port_local_dns">Local DNS port</string>
   <string name="port_transproxy">Transproxy port</string>
+  <string name="connection_test_url">Connection test URL</string>
 
   <string name="remote_dns">Remote DNS</string>
   <string name="traffic">%1$s↑\t%2$s↓</string>

--- a/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
+++ b/mobile/src/main/java/com/github/shadowsocks/GlobalSettingsPreferenceFragment.kt
@@ -59,6 +59,8 @@ class GlobalSettingsPreferenceFragment : PreferenceFragmentCompat() {
         portLocalDns.setOnBindEditTextListener(EditTextPreferenceModifiers.Port)
         val portTransproxy = findPreference<EditTextPreference>(Key.portTransproxy)!!
         portTransproxy.setOnBindEditTextListener(EditTextPreferenceModifiers.Port)
+        val connectionTestUrl = findPreference<EditTextPreference>(Key.connectionTestUrl)!!
+        connectionTestUrl.setOnBindEditTextListener(EditTextPreferenceModifiers.Url)
         val onServiceModeChange = Preference.OnPreferenceChangeListener { _, newValue ->
             portTransproxy.isEnabled = newValue as String? == Key.modeTransproxy
             true

--- a/mobile/src/main/res/xml/pref_global.xml
+++ b/mobile/src/main/res/xml/pref_global.xml
@@ -34,4 +34,8 @@
         app:key="portTransproxy"
         app:title="@string/port_transproxy"
         app:useSimpleSummaryProvider="true"/>
+    <EditTextPreference
+        app:key="connectionTestUrl"
+        app:title="@string/connection_test_url"
+        app:useSimpleSummaryProvider="true"/>
 </PreferenceScreen>

--- a/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
+++ b/tv/src/main/java/com/github/shadowsocks/tv/MainPreferenceFragment.kt
@@ -141,6 +141,8 @@ class MainPreferenceFragment : LeanbackPreferenceFragmentCompat(), ShadowsocksCo
         portLocalDns.setOnBindEditTextListener(EditTextPreferenceModifiers.Port)
         portTransproxy = findPreference(Key.portTransproxy)!!
         portTransproxy.setOnBindEditTextListener(EditTextPreferenceModifiers.Port)
+        findPreference<EditTextPreference>(Key.connectionTestUrl)!!
+                .setOnBindEditTextListener(EditTextPreferenceModifiers.Url)
         serviceMode.onPreferenceChangeListener = onServiceModeChange
         findPreference<Preference>(Key.about)!!.summary = getString(R.string.about_title, BuildConfig.VERSION_NAME)
 

--- a/tv/src/main/res/xml/pref_main.xml
+++ b/tv/src/main/res/xml/pref_main.xml
@@ -48,6 +48,10 @@
             app:key="portTransproxy"
             app:title="@string/port_transproxy"
             app:useSimpleSummaryProvider="true"/>
+        <EditTextPreference
+            app:key="connectionTestUrl"
+            app:title="@string/connection_test_url"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
 
     <Preference


### PR DESCRIPTION
Summary:
- Add a public setting for the connection test URL.
- Preserve `https://cp.cloudflare.com` as the initialized default.
- Use the configured URL when running the HTTPS connectivity test.
- Add the setting to both mobile and TV settings.

Why:
Some networks cannot reach the default connectivity endpoint. Letting users choose the URL makes the connection test useful in those environments without changing proxy behavior.

Closes #3225.

Validation:
- git diff --check
- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/andy/Library/Android/sdk ./gradlew :mobile:compileDebugKotlin :tv:compileGoogleDebugKotlin
- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/andy/Library/Android/sdk ./gradlew :mobile:installDebug
- Emulator smoke: launched the debug app, opened Settings > Advanced, and verified `Connection test URL` shows `https://cp.cloudflare.com`.

Please preserve author attribution if this PR is squashed or reworked:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
